### PR TITLE
Remove unneeded indirection in types definitions in core.

### DIFF
--- a/src/core/components/arrows.ml
+++ b/src/core/components/arrows.ml
@@ -21,8 +21,8 @@ module Make(N:Node) = struct
   type t = Bdd.t
   type node = N.t
 
-  let any () = Bdd.any ()
-  let empty () = Bdd.empty ()
+  let any = Bdd.any
+  let empty = Bdd.empty
   let mk a = Bdd.singleton a
 
   let cap = Bdd.cap

--- a/src/core/components/atoms.ml
+++ b/src/core/components/atoms.ml
@@ -9,8 +9,8 @@ module Make(N:Node) = struct
   type t = Pos of ASet.t | Neg of ASet.t
   type node = N.t
 
-  let any () = Neg ASet.empty
-  let empty () = Pos ASet.empty
+  let any = Neg ASet.empty
+  let empty = Pos ASet.empty
 
   let mk e = Pos (ASet.singleton e)
   let construct (n,es) =

--- a/src/core/components/intervals.ml
+++ b/src/core/components/intervals.ml
@@ -82,8 +82,8 @@ module Make(N:Node) = struct
   module ISet = Set.Make(Interval)
   type t = ISet.t
 
-  let empty () = ISet.empty
-  let any () = ISet.singleton Interval.any
+  let empty = ISet.empty
+  let any = ISet.singleton Interval.any
   let mk i = ISet.singleton i
 
   let normalize t =

--- a/src/core/components/records.ml
+++ b/src/core/components/records.ml
@@ -69,7 +69,7 @@ module Atom(N:Node) = struct
     LabelMap.equal OTy.equal t1.bindings t2.bindings
   let compare t1 t2 =
     compare t1.opened t2.opened |> ccmp
-    (LabelMap.compare OTy.compare) t1.bindings t2.bindings
+      (LabelMap.compare OTy.compare) t1.bindings t2.bindings
 end
 
 module Atom'(N:Node) = struct
@@ -119,8 +119,8 @@ module Atom'(N:Node) = struct
     LabelMap.equal OTy.equal t1.bindings t2.bindings
   let compare t1 t2 =
     compare t1.opened t2.opened |> ccmp
-    (Option.compare LabelSet.compare) t1.required t2.required |> ccmp
-    (LabelMap.compare OTy.compare) t1.bindings t2.bindings
+      (Option.compare LabelSet.compare) t1.required t2.required |> ccmp
+      (LabelMap.compare OTy.compare) t1.bindings t2.bindings
 end
 
 module Make(N:Node) = struct
@@ -133,8 +133,8 @@ module Make(N:Node) = struct
   type t = Bdd.t
   type node = N.t
 
-  let any () = Bdd.any ()
-  let empty () = Bdd.empty ()
+  let any = Bdd.any
+  let empty = Bdd.empty
 
   let mk a = Bdd.singleton a
 
@@ -155,22 +155,22 @@ module Make(N:Node) = struct
     | [], [] -> []
     | s::ss, t::tt ->
       let res1 = distribute_diff ss tt
-      |> List.map (fun ss -> s::ss) in
+                 |> List.map (fun ss -> s::ss) in
       let res2 = (ON.diff s t)::ss in
       res2::res1
     | _, _ -> assert false
   let rec psi n ss ts =
     if List.exists2 ON.leq ss (disj n ts) |> not then false (* optimisation *)
     else match ts with
-    | [] -> (* List.exists ON.is_empty ss *) true
-    | tt::ts ->
-      List.exists ON.is_empty ss || (* optimisation *)
-      distribute_diff ss tt |> List.for_all (fun ss -> psi n ss ts)
+      | [] -> (* List.exists ON.is_empty ss *) true
+      | tt::ts ->
+        List.exists ON.is_empty ss || (* optimisation *)
+        distribute_diff ss tt |> List.for_all (fun ss -> psi n ss ts)
   let is_clause_empty (ps,ns,b) =
     if b then
       let dom = List.fold_left
-        (fun acc a -> LabelSet.union acc (Atom.dom a))
-        LabelSet.empty (ps@ns) |> LabelSet.to_list in
+          (fun acc a -> LabelSet.union acc (Atom.dom a))
+          LabelSet.empty (ps@ns) |> LabelSet.to_list in
       let ps, ns =
         ps |> List.map (Atom.to_tuple_with_default dom),
         ns |> List.map (Atom.to_tuple_with_default dom) in
@@ -231,8 +231,8 @@ module Make(N:Node) = struct
       let open Atom' in
       let dom = LabelSet.union (dom s1) (dom s2) in
       let bindings = dom |> LabelSet.to_list |> List.map (fun lbl ->
-        (lbl, OTy.cap (find lbl s1) (find lbl s2))
-      ) |> LabelMap.of_list in
+          (lbl, OTy.cap (find lbl s1) (find lbl s2))
+        ) |> LabelMap.of_list in
       let opened = s1.opened && s2.opened in
       let required =
         match s1.required, s2.required with
@@ -248,7 +248,7 @@ module Make(N:Node) = struct
 
   let dnf t = Bdd.dnf t |> Dnf.mk
   let dnf' t = dnf t |> Dnf'.from_dnf
-    ({ Atom'.bindings=LabelMap.empty ; opened=true ; required=None })
+                 ({ Atom'.bindings=LabelMap.empty ; opened=true ; required=None })
   let of_dnf dnf = Dnf.mk dnf |> Bdd.of_dnf
   let of_dnf' dnf' = of_dnf (Dnf'.to_dnf dnf')
 

--- a/src/core/components/tags.ml
+++ b/src/core/components/tags.ml
@@ -27,8 +27,8 @@ module MakeC(N:Node) = struct
   type t = Tag.t * Bdd.t
   type node = N.t
 
-  let any n = n, Bdd.any ()
-  let empty n = n, Bdd.empty ()
+  let any n = n, Bdd.any
+  let empty n = n, Bdd.empty
 
   let mk a = Atom.tag a, Bdd.singleton a
 

--- a/src/core/components/tuples.ml
+++ b/src/core/components/tuples.ml
@@ -23,8 +23,8 @@ module MakeC(N:Node) = struct
   type t = int * Bdd.t
   type node = N.t
 
-  let any n = n, Bdd.any ()
-  let empty n = n, Bdd.empty ()
+  let any n = n, Bdd.any
+  let empty n = n, Bdd.empty
 
   let mk a = Atom.tag a, Bdd.singleton a
 
@@ -95,13 +95,13 @@ module MakeC(N:Node) = struct
 
     let to_t a = [a], []
     let to_t' (ns,b) =
-      let any_tuple n = List.init n (fun _ -> N.any ()) in
+      let any_tuple n = List.init n (fun _ -> N.any()) in
       let rec aux ns =
         match ns with
         | [] -> []
         | n::ns ->
           let this = (N.neg n)::(any_tuple (List.length ns)) in
-          let others = aux ns |> List.map (fun s -> (N.any ())::s) in
+          let others = aux ns |> List.map (fun s -> (N.any())::s) in
           this::others
       in
       if b then [ns] else aux ns

--- a/src/core/descr.ml
+++ b/src/core/descr.ml
@@ -27,30 +27,30 @@ module Make(N:Node) = struct
   }
   type node = N.t
 
-  let any () = {
-    atoms = Atoms.any () ;
-    tags = Tags.any () ;
-    tuples = Tuples.any () ;
-    arrows = Arrows.any () ;
-    records = Records.any () ;
-    intervals = Intervals.any ()
+  let any = {
+    atoms = Atoms.any ;
+    tags = Tags.any  ;
+    tuples = Tuples.any ;
+    arrows = Arrows.any ;
+    records = Records.any ;
+    intervals = Intervals.any
   }
 
-  let empty () = {
-    atoms = Atoms.empty () ;
-    tags = Tags.empty () ;
-    tuples = Tuples.empty () ;
-    arrows = Arrows.empty () ;
-    records = Records.empty () ;
-    intervals = Intervals.empty ()
+  let empty = {
+    atoms = Atoms.empty ;
+    tags = Tags.empty;
+    tuples = Tuples.empty;
+    arrows = Arrows.empty;
+    records = Records.empty;
+    intervals = Intervals.empty
   }
 
-  let mk_atoms a = { (empty ()) with atoms = a }
-  let mk_tags a = { (empty ()) with tags = a }
-  let mk_arrows a = { (empty ()) with arrows = a }
-  let mk_tuples a = { (empty ()) with tuples = a }
-  let mk_records a = { (empty ()) with records = a }
-  let mk_intervals a = { (empty ()) with intervals = a }
+  let mk_atoms a = { empty with atoms = a }
+  let mk_tags a = { empty with tags = a }
+  let mk_arrows a = { empty with arrows = a }
+  let mk_tuples a = { empty with tuples = a }
+  let mk_records a = { empty with records = a }
+  let mk_intervals a = { empty with intervals = a }
 
   let mk_atom a = Atoms.mk a |> mk_atoms
   let mk_tagcomp a = Tags.mk_comp a |> mk_tags
@@ -79,8 +79,8 @@ module Make(N:Node) = struct
     | Tags tags -> { t with tags }
     | Tuples tuples -> { t with tuples }
     | Records records -> { t with records }
-  let of_component = set_component (empty ())
-  let of_components = List.fold_left set_component (empty ())
+  let of_component = set_component empty
+  let of_components = List.fold_left set_component empty
 
   let unop fato ftag ftup farr frec fint t = {
     atoms = fato t.atoms ;

--- a/src/core/node.ml
+++ b/src/core/node.ml
@@ -3,8 +3,6 @@ open Sigs
 open Effect.Deep
 open Effect
 
-let () = Printexc.record_backtrace true
-
 module rec Node : Node with type vdescr = VDescr.t and type descr = VDescr.Descr.t = struct
 
   module NSet = Set.Make(Node)

--- a/src/core/node.ml
+++ b/src/core/node.ml
@@ -3,8 +3,9 @@ open Sigs
 open Effect.Deep
 open Effect
 
-module rec Node : Node = struct
-  module VDescr = Vdescr.Make(Node)
+let () = Printexc.record_backtrace true
+
+module rec Node : Node with type vdescr = VDescr.t and type descr = VDescr.Descr.t = struct
 
   module NSet = Set.Make(Node)
   module NMap = Map.Make(Node)
@@ -12,12 +13,16 @@ module rec Node : Node = struct
   type _ Effect.t += GetCache: unit -> (bool VDMap.t) t
   type _ Effect.t += SetCache: bool VDMap.t -> unit t
 
+  type vdescr = VDescr.t
+  type descr = VDescr.Descr.t
+
   type t = {
     id : int ;
     neg : t ; (* Always generate the negation node as it is very easy to compute *)
     mutable def : VDescr.t option ;
     mutable simplified : bool ;
   }
+  type node = t
 
   let has_def t = Option.is_some t.def
   let def t = t.def |> Option.get
@@ -58,10 +63,10 @@ module rec Node : Node = struct
 
   let of_def d = d |> cons
 
-  let any = VDescr.any () |> cons
-  let empty =  VDescr.empty () |> cons
-  let any () = any
-  let empty () = empty
+  let any, empty =
+    let any =  VDescr.any |> cons in
+    let empty = any.neg in
+    (fun () -> any), (fun () -> empty)
 
   let cap t1 t2 =
     VDescr.cap (def t1) (def t2) |> cons
@@ -76,7 +81,7 @@ module rec Node : Node = struct
   let is_empty t =
     let def = def t in
     if t.simplified then
-      VDescr.equal def (VDescr.empty ())
+      VDescr.equal def VDescr.empty
     else
       let cache = perform (GetCache ()) in
       begin match VDMap.find_opt def cache with
@@ -180,9 +185,10 @@ module rec Node : Node = struct
       define (new_node n) d
     ) ;
     new_node t
-  
+
   let mk_var v = VDescr.mk_var v |> cons
   let mk_descr d = VDescr.mk_descr d |> cons
   let get_descr t = def t |> VDescr.get_descr
   let nodes t = dependencies t |> NSet.to_list
 end
+and VDescr : VDescr with type node = Node.t = Vdescr.Make(Node)

--- a/src/core/sigs.ml
+++ b/src/core/sigs.ml
@@ -462,7 +462,7 @@ module type Node = sig
   type vdescr
   type descr
 
-  include TyBaseRef with type t := t and type node := node  
+  include TyBaseRef with type t := t and type node := node
 
   val def : t -> vdescr
   val of_def : vdescr -> t
@@ -492,6 +492,16 @@ module type Ty = sig
   include TyBase with type t:=t and type node:=t
 
   module VDescr : VDescr with type node := t
+
+  module O : sig
+    type node = t
+    type t = node * bool
+    include TyBase with type node := node and type t := t
+    val absent : t
+
+    include SetTheoretic with type t := t
+    val is_absent : t -> bool
+  end
 
   val any : t
   val empty : t

--- a/src/core/sstt_core.ml
+++ b/src/core/sstt_core.ml
@@ -8,13 +8,13 @@ module Ty : Ty = struct
 
   type t = N.t
 
-  module VDescr = N.VDescr
+  module VDescr = Node.VDescr
 
   let simpl t = N.with_own_cache N.simplify t ; t
   let s f t = f t |> simpl
   let s' f t = simpl t |> f
 
-  let any, empty = N.any () |> simpl, N.empty () |> simpl
+  let any, empty = N.any ()|> simpl, N.empty ()|> simpl
   let def, of_def = s' N.def, s N.of_def
 
   let mk_var, mk_descr, get_descr = s N.mk_var, s N.mk_descr, s' N.get_descr

--- a/src/core/sstt_core.ml
+++ b/src/core/sstt_core.ml
@@ -9,6 +9,11 @@ module Ty : Ty = struct
   type t = N.t
 
   module VDescr = Node.VDescr
+  module O = struct
+    type node = t
+    include VDescr.Descr.Records.Atom.OTy
+    let any, empty, absent = any (), empty (), absent ()
+  end
 
   let simpl t = N.with_own_cache N.simplify t ; t
   let s f t = f t |> simpl
@@ -38,7 +43,6 @@ module Ty : Ty = struct
 
   let compare, equal, hash = N.compare, N.equal, N.hash
 end
-
 module VDescr = Ty.VDescr
 module Descr = VDescr.Descr
 module Arrows = Descr.Arrows

--- a/src/core/utils/bdd.ml
+++ b/src/core/utils/bdd.ml
@@ -2,8 +2,8 @@ open Sstt_utils
 
 module type Leaf = sig
   type t
-  val any : unit -> t
-  val empty : unit -> t
+  val any : t
+  val empty : t
   val cap : t -> t -> t
   val cup : t -> t -> t
   val diff : t -> t -> t
@@ -15,8 +15,8 @@ end
 
 module BoolLeaf : Leaf with type t = bool = struct
   type t = bool
-  let any () = true
-  let empty () = false
+  let any = true
+  let empty = false
   let cap = (&&)
   let cup = (||)
   let diff b1 b2 = b1 && not b2
@@ -38,11 +38,11 @@ module Make(N:Atom)(L:Leaf) = struct
   | Node of N.t * t * t
   | Leaf of L.t
 
-  let empty () = Leaf (L.empty ())
-  let any () = Leaf (L.any ())
+  let empty = Leaf (L.empty)
+  let any = Leaf (L.any)
 
-  let singleton a = Node (a, any (), empty ())
-  let nsingleton a = Node (a, empty (), any ())
+  let singleton a = Node (a, any, empty)
+  let nsingleton a = Node (a, empty, any)
   let mk_leaf l = Leaf l
 
   let rec equal t1 t2 =
@@ -126,8 +126,8 @@ module Make(N:Atom)(L:Leaf) = struct
     in
     aux [] [] [] t
 
-  let conj = List.fold_left cap (any ())
-  let disj = List.fold_left cup (empty ())
+  let conj = List.fold_left cap any
+  let disj = List.fold_left cup empty
   let of_dnf dnf =
     let line (ps,ns,l) =
       let ps = ps |> List.map singleton in

--- a/src/core/utils/tagged.ml
+++ b/src/core/utils/tagged.ml
@@ -43,8 +43,8 @@ module Make(N:Node)(C:TaggedComp with type node = N.t) = struct
       let map = cs |> List.map (fun a -> (C.tag a, C.neg a)) |> TMap.of_list in
       { map ; others=true }
   
-  let any () = { map = TMap.empty ; others = true }
-  let empty () = { map = TMap.empty ; others = false }
+  let any = { map = TMap.empty ; others = true }
+  let empty = { map = TMap.empty ; others = false }
 
   let cap t1 t2 =
     let others = t1.others && t2.others in

--- a/src/core/vdescr.ml
+++ b/src/core/vdescr.ml
@@ -7,18 +7,19 @@ module Atom = struct
 end
 
 module Make(N:Node) = struct
+
   module Descr = Descr.Make(N)
   module Bdd = Bdd.Make(Atom)(Descr)
 
   type t = Bdd.t
   type node = N.t
 
-  let any () = Bdd.any ()
-  let empty () = Bdd.empty ()
+  let any = Bdd.any
+  let empty = Bdd.empty
 
   let mk_var a = Bdd.singleton a
   let mk_descr d = Bdd.mk_leaf d
-  let get_descr t = Bdd.leaves t |> List.fold_left Descr.cup (Descr.empty ())
+  let get_descr t = Bdd.leaves t |> List.fold_left Descr.cup Descr.empty
 
   let cap = Bdd.cap
   let cup = Bdd.cup
@@ -54,7 +55,7 @@ module Make(N:Node) = struct
     type leaf = Descr.t
     type t = Var.t
 
-    let undesirable_leaf l = Descr.equal l (Descr.empty ())
+    let undesirable_leaf l = Descr.equal l Descr.empty
     let leq t1 t2 = leq (Bdd.of_dnf t1) (Bdd.of_dnf t2)
   end
   module Dnf = Dnf.Make(DnfAtom)(N)

--- a/src/parsing/ast.ml
+++ b/src/parsing/ast.ml
@@ -61,12 +61,12 @@ let empty_env = {
 let builtin t =
   match t with
   | TEmpty -> Ty.empty | TAny -> Ty.any
-  | TAnyAtom -> Descr.mk_atoms (Atoms.any ()) |> Ty.mk_descr
-  | TAnyTag -> Descr.mk_tags (Tags.any ()) |> Ty.mk_descr
-  | TAnyInt -> Descr.mk_intervals (Intervals.any ()) |> Ty.mk_descr
-  | TAnyTuple -> Descr.mk_tuples (Tuples.any ()) |> Ty.mk_descr
-  | TAnyArrow -> Descr.mk_arrows (Arrows.any ()) |> Ty.mk_descr
-  | TAnyRecord -> Descr.mk_records (Records.any ()) |> Ty.mk_descr
+  | TAnyAtom -> Descr.mk_atoms Atoms.any |> Ty.mk_descr
+  | TAnyTag -> Descr.mk_tags Tags.any |> Ty.mk_descr
+  | TAnyInt -> Descr.mk_intervals Intervals.any |> Ty.mk_descr
+  | TAnyTuple -> Descr.mk_tuples Tuples.any |> Ty.mk_descr
+  | TAnyArrow -> Descr.mk_arrows Arrows.any |> Ty.mk_descr
+  | TAnyRecord -> Descr.mk_records Records.any |> Ty.mk_descr
   | TAnyTupleComp n -> TupleComp.any n |> Descr.mk_tuplecomp |> Ty.mk_descr
   | TAnyTagComp t -> TagComp.any t |> Descr.mk_tagcomp |> Ty.mk_descr
 

--- a/src/types/extensions/abstracts.ml
+++ b/src/types/extensions/abstracts.ml
@@ -39,7 +39,7 @@ let mk tag ps =
   (tag, ty) |> Descr.mk_tag |> Ty.mk_descr
 
 let mk_any tag =
-  let arrow = Arrows.any () |> Descr.mk_arrows |> Ty.mk_descr in
+  let arrow = Arrows.any |> Descr.mk_arrows |> Ty.mk_descr in
   (tag, arrow) |> Descr.mk_tag |> Ty.mk_descr
 
 let is_abstract tag = Hashtbl.mem atypes tag
@@ -85,7 +85,7 @@ let extract_params vs ty =
     res |> List.map (fun (ps, ns) ->
       let ps = ps |> List.map (encode_params vs) |> Ty.conj in
       let ns = ns |> List.map (encode_params vs) |> List.map Ty.neg |> Ty.conj in
-      let arrow = Arrows.any () |> Descr.mk_arrows |> Ty.mk_descr in
+      let arrow = Arrows.any |> Descr.mk_arrows |> Ty.mk_descr in
       Ty.cap arrow (Ty.cap ps ns)
     ) |> Ty.disj
   in

--- a/src/types/extensions/strings.ml
+++ b/src/types/extensions/strings.ml
@@ -18,7 +18,7 @@ let str str =
     Hashtbl.add strings atom str ;
     atom |> Descr.mk_atom |> Ty.mk_descr |> add_tag
 
-let any = Atoms.any () |> Descr.mk_atoms |> Ty.mk_descr |> add_tag
+let any = Atoms.any |> Descr.mk_atoms |> Ty.mk_descr |> add_tag
 
 let extract ty =
   let open Printer in

--- a/src/types/op.ml
+++ b/src/types/op.ml
@@ -73,7 +73,7 @@ module Records = struct
     let union_a a1 a2 =
       let dom = LabelSet.union (dom a1) (dom a2) in
       let bindings = dom |> LabelSet.to_list |> List.map (fun lbl ->
-        (lbl, OTy.cup (find lbl a1) (find lbl a2))
+        (lbl, Ty.O.cup (find lbl a1) (find lbl a2))
       ) |> LabelMap.of_list in
       { bindings ; opened = a1.opened || a2.opened }
     in
@@ -82,21 +82,21 @@ module Records = struct
     | hd::tl -> List.fold_left union_a hd tl
 
   let proj label t =
-    as_union t |> List.map (Records.Atom.find label) |> Records.Atom'.OTy.disj
+    as_union t |> List.map (Records.Atom.find label) |> Ty.O.disj
 
   let merge a1 a2 =
     let open Records.Atom in
     let dom = LabelSet.union (dom a1) (dom a2) in
     let bindings = dom |> LabelSet.to_list |> List.map (fun lbl ->
       let oty1, oty2 = find lbl a1, find lbl a2 in
-      let oty = if snd oty2 then OTy.cup oty1 (fst oty2, false) else oty2 in
+      let oty = if snd oty2 then Ty.O.cup oty1 (fst oty2, false) else oty2 in
       (lbl, oty)
     ) |> LabelMap.of_list in
     { bindings ; opened = a1.opened && a2.opened } |> Records.mk
 
   let remove a lbl =
     let open Records.Atom in
-    let bindings = a.bindings |> LabelMap.add lbl (OTy.absent ()) in
+    let bindings = a.bindings |> LabelMap.add lbl (Ty.O.absent) in
     { a with bindings } |> Records.mk
 
 end

--- a/src/types/op.mli
+++ b/src/types/op.mli
@@ -52,7 +52,7 @@ module Records : sig
 
     (** [proj l t] returns the (possibly absent) type resulting
     from the projection on the label [l] of [t]. *)
-    val proj : Label.t -> t -> Records.Atom.OTy.t
+    val proj : Label.t -> t -> Ty.O.t
 
     (** [merge t1 t2] returns the atom resulting from the merging of
     [t1] and [t2] (non-absent fields in [t2] override those in [t1]). *)

--- a/src/types/printer.ml
+++ b/src/types/printer.ml
@@ -394,22 +394,22 @@ let resolve_comp ctx c =
   match c with
   | D.Atoms c ->
     alias_or resolve_atoms c,
-    { op = Builtin AnyAtom ; ty = Atoms.any () |> D.mk_atoms |> Ty.mk_descr }
+    { op = Builtin AnyAtom ; ty = Atoms.any |> D.mk_atoms |> Ty.mk_descr }
   | D.Arrows c ->
     alias_or resolve_arrows c,
-    { op = Builtin AnyArrow ; ty = Arrows.any () |> D.mk_arrows |> Ty.mk_descr }
+    { op = Builtin AnyArrow ; ty = Arrows.any |> D.mk_arrows |> Ty.mk_descr }
   | D.Intervals c ->
     alias_or resolve_intervals c,
-    { op = Builtin AnyInt ; ty = Intervals.any () |> D.mk_intervals |> Ty.mk_descr }
+    { op = Builtin AnyInt ; ty = Intervals.any |> D.mk_intervals |> Ty.mk_descr }
   | D.Tags c ->
     alias_or resolve_tags c,
-    { op = Builtin AnyTag ; ty = Tags.any () |> D.mk_tags |> Ty.mk_descr }
+    { op = Builtin AnyTag ; ty = Tags.any |> D.mk_tags |> Ty.mk_descr }
   | D.Tuples c ->
     alias_or resolve_tuples c,
-    { op = Builtin AnyTuple; ty = Tuples.any () |> D.mk_tuples |> Ty.mk_descr }
+    { op = Builtin AnyTuple; ty = Tuples.any |> D.mk_tuples |> Ty.mk_descr }
   | D.Records c ->
     alias_or resolve_records c,
-    { op = Builtin AnyRecord ; ty = Records.any () |> D.mk_records |> Ty.mk_descr }
+    { op = Builtin AnyRecord ; ty = Records.any |> D.mk_records |> Ty.mk_descr }
 
 let resolve_descr ctx d =
   let ty = VD.mk_descr d |> Ty.of_def in

--- a/src/types/tallying.ml
+++ b/src/types/tallying.ml
@@ -233,12 +233,12 @@ module Make(VO:VarOrder) = struct
         ns |> List.map (to_tuple_with_default dom) in
       let n = List.length dom + 1 in
     (* We reuse the same algorithm as for tuples *)
-      let ps = mapn (fun () -> List.init n (fun _ -> OTy.any ())) OTy.conj ps in
+      let ps = mapn (fun () -> List.init n (fun _ -> Ty.O.any)) Ty.O.conj ps in
       let aux_n nss =
         let csss = nss |> List.mapi (fun i ns ->
           let pcomp = List.nth ps i in
-          let ncomp = ns |> List.map (fun ns -> List.nth ns i) |> OTy.disj |> OTy.neg in
-          OTy.cap pcomp ncomp |> aux_oty m
+          let ncomp = ns |> List.map (fun ns -> List.nth ns i) |> Ty.O.disj |> Ty.O.neg in
+          Ty.O.cap pcomp ncomp |> aux_oty m
         ) in
         NCSS.disj csss
       in

--- a/src/types/transform.ml
+++ b/src/types/transform.ml
@@ -49,7 +49,7 @@ let regroup_records conjuncts =
     LabelSet.to_list in
   let tuples = conjuncts |> List.map (Records.Atom.to_tuple dom) in
   try
-    let tuple = mapn (fun () -> raise Exit) Records.Atom.OTy.conj tuples in
+    let tuple = mapn (fun () -> raise Exit) Ty.O.conj tuples in
     let bindings = List.combine dom tuple |> LabelMap.of_list in
     let opened = List.for_all (fun a -> a.Records.Atom.opened) conjuncts in
     [{ Records.Atom.bindings ; opened }]


### PR DESCRIPTION
The recursive type algebra of semantic subtyping is implemented as a set of mutually recursive modules:
   - Node (type references)
   - VDescr (Bdd of type variables whose leafs are ...)
   - Descr (disjoint union of components)
   - Componenents (Integers, Atoms, Tuples, Arrows). Constructors such as Tuples and Arrows are built on top of Node

To be valid OCaml definitions, at least one of these modules must only contains function value definitions.

This commit refactors the type definitions by introducing two distinct signatures :
- `TyBase` for which the type of `any` and `empty` is `t`
- `TyBaseRef` for which the type of `any` and `empty` is `unit -> t`

`TyBaseRef` is now used only for `Node` and its direct user `OTy`, and `TyBase` everywhere else.

The commit also makes it so that `Node.any.neg == Node.empty` (the two nodes are built in the same definition).