### PR TITLE
Stratify type definitions

### DIFF
--- a/src/core/components/arrows.ml
+++ b/src/core/components/arrows.ml
@@ -1,28 +1,27 @@
 open Sigs
 open Sstt_utils
 
-module Atom(N:Node) = struct
-  type node = N.t
-  type t = node * node
+module Atom = struct
+  type node = Tdefs.node
+  type t = Tdefs.arrow_atom
   let map_nodes f (n1,n2) = (f n1, f n2)
   let direct_nodes (n1,n2) = [n1;n2]
   let simplify t = t
   let equal (s1,t1) (s2,t2) =
-    N.equal s1 s2 && N.equal t1 t2
+    Tdefs.N.equal s1 s2 && Tdefs.N.equal t1 t2
   let compare (s1,t1) (s2,t2) =
-    N.compare s1 s2 |> ccmp
-    N.compare t1 t2
+    Tdefs.N.compare s1 s2 |> ccmp
+    Tdefs.N.compare t1 t2
 end
 
-module Make(N:Node) = struct
-  module Atom = Atom(N)
+module Make(N : Node) = struct
+  module Atom = Atom
   module Bdd = Bdd.Make(Atom)(Bdd.BoolLeaf)
 
-  type t = Bdd.t
-  type node = N.t
+  type t = Tdefs.arrows
+  let any = Tdefs.any_descr.arrows
+  let empty = Tdefs.empty_descr.arrows
 
-  let any = Bdd.any
-  let empty = Bdd.empty
   let mk a = Bdd.singleton a
 
   let cap = Bdd.cap

--- a/src/core/components/atoms.ml
+++ b/src/core/components/atoms.ml
@@ -1,59 +1,52 @@
-open Sigs
-
 module Atom = Id.NamedIdentifier()
+module ASet = Set.Make(Atom)
 
-module Make(N:Node) = struct
-  module Atom = Atom
-  module ASet = Set.Make(Atom)
+type t = Pos of ASet.t | Neg of ASet.t
 
-  type t = Pos of ASet.t | Neg of ASet.t
-  type node = N.t
+let any = Neg ASet.empty
+let empty = Pos ASet.empty
 
-  let any = Neg ASet.empty
-  let empty = Pos ASet.empty
-
-  let mk e = Pos (ASet.singleton e)
-  let construct (n,es) =
-    let es = ASet.of_list es in
-    if n then Pos es else Neg es
-  let destruct t = match t with
+let mk e = Pos (ASet.singleton e)
+let construct (n,es) =
+  let es = ASet.of_list es in
+  if n then Pos es else Neg es
+let destruct t = match t with
   | Pos s -> true, ASet.elements s
   | Neg s -> false, ASet.elements s
 
-  let cap t1 t2 =
-    match t1, t2 with
-    | Pos p1, Pos p2 -> Pos (ASet.inter p1 p2)
-    | Neg n1, Neg n2 -> Neg (ASet.union n1 n2)
-    | Pos p, Neg n | Neg n, Pos p -> Pos (ASet.diff p n)
-  let cup t1 t2 =
-    match t1, t2 with
-    | Pos p1, Pos p2 -> Pos (ASet.union p1 p2)
-    | Neg n1, Neg n2 -> Neg (ASet.inter n1 n2)
-    | Pos p, Neg n | Neg n, Pos p -> Neg (ASet.diff n p)
-  let neg = function
+let cap t1 t2 =
+  match t1, t2 with
+  | Pos p1, Pos p2 -> Pos (ASet.inter p1 p2)
+  | Neg n1, Neg n2 -> Neg (ASet.union n1 n2)
+  | Pos p, Neg n | Neg n, Pos p -> Pos (ASet.diff p n)
+let cup t1 t2 =
+  match t1, t2 with
+  | Pos p1, Pos p2 -> Pos (ASet.union p1 p2)
+  | Neg n1, Neg n2 -> Neg (ASet.inter n1 n2)
+  | Pos p, Neg n | Neg n, Pos p -> Neg (ASet.diff n p)
+let neg = function
   | Pos s -> Neg s
   | Neg s -> Pos s
-  let diff t1 t2 = cap t1 (neg t2)
+let diff t1 t2 = cap t1 (neg t2)
 
-  let is_any = function
+let is_any = function
   | Pos _ -> false
   | Neg n -> ASet.is_empty n
 
-  let is_empty = function
+let is_empty = function
   | Pos p -> ASet.is_empty p
   | Neg _ -> false
 
-  let compare t1 t2 =
-    match t1, t2 with
-    | Pos _, Neg _ -> 1
-    | Neg _, Pos _ -> -1
-    | Pos s1, Pos s2 | Neg s1, Neg s2 -> ASet.compare s1 s2
-  let equal t1 t2 =
-    match t1, t2 with
-    | Pos _, Neg _ | Neg _, Pos _ -> false
-    | Pos s1, Pos s2 | Neg s1, Neg s2 -> ASet.equal s1 s2
+let compare t1 t2 =
+  match t1, t2 with
+  | Pos _, Neg _ -> 1
+  | Neg _, Pos _ -> -1
+  | Pos s1, Pos s2 | Neg s1, Neg s2 -> ASet.compare s1 s2
+let equal t1 t2 =
+  match t1, t2 with
+  | Pos _, Neg _ | Neg _, Pos _ -> false
+  | Pos s1, Pos s2 | Neg s1, Neg s2 -> ASet.equal s1 s2
 
-  let direct_nodes _ = []
-  let map_nodes _ t = t
-  let simplify t = t
-end
+let direct_nodes _ = []
+let map_nodes _ t = t
+let simplify t = t

--- a/src/core/components/intervals.ml
+++ b/src/core/components/intervals.ml
@@ -76,7 +76,7 @@ module Interval = struct
 end
 
 module Atom = Interval
-type node
+
 module ISet = Set.Make(Interval)
 type t = ISet.t
 

--- a/src/core/components/tags.ml
+++ b/src/core/components/tags.ml
@@ -1,12 +1,11 @@
 open Sigs
 open Sstt_utils
-
-module Tag = Id.NamedIdentifier()
+open Tdefs
 
 module Atom(N:Node) = struct
   module Tag = Tag
-  type node = N.t
-  type t = Tag.t * node
+
+  type t = Tdefs.tag_atom
   let tag (tag,_) = tag
   let map_nodes f (t,n) = t, f n
   let direct_nodes (_,n) = [n]
@@ -24,8 +23,7 @@ module MakeC(N:Node) = struct
   module Bdd = Bdd.Make(Atom)(Bdd.BoolLeaf)
   module Tag = Atom.Tag
 
-  type t = Tag.t * Bdd.t
-  type node = N.t
+  type t = Tdefs.tag_comp
 
   let any n = n, Bdd.any
   let empty n = n, Bdd.empty

--- a/src/core/components/tags.ml
+++ b/src/core/components/tags.ml
@@ -89,7 +89,7 @@ end
 
 module Make(N:Node) = struct
   module TagComp = MakeC(N)
-  include Tagged.Make(N)(TagComp)
+  include Tagged.Make(TagComp)
 
   let mk_comp p = mk p
   let mk a = mk (TagComp.mk a)

--- a/src/core/components/tuples.ml
+++ b/src/core/components/tuples.ml
@@ -134,7 +134,7 @@ end
 
 module Make(N:Node) = struct
   module TupleComp = MakeC(N)
-  include Tagged.Make(N)(TupleComp)
+  include Tagged.Make (TupleComp)
 
   let mk_comp p = mk p
   let mk a = mk (TupleComp.mk a)

--- a/src/core/components/tuples.ml
+++ b/src/core/components/tuples.ml
@@ -2,8 +2,7 @@ open Sigs
 open Sstt_utils
 
 module Atom(N:Node) = struct
-  type node = N.t
-  type t = node list
+  type t = Tdefs.tuple_atom
   let tag t = List.length t
   let map_nodes f t = List.map f t
   let direct_nodes t = t
@@ -21,7 +20,6 @@ module MakeC(N:Node) = struct
   module Tag = Int
 
   type t = int * Bdd.t
-  type node = N.t
 
   let any n = n, Bdd.any
   let empty n = n, Bdd.empty
@@ -41,10 +39,10 @@ module MakeC(N:Node) = struct
   let diff (tag1, t1) (tag2, t2) = check_tag tag1 tag2 ; tag1, Bdd.diff t1 t2
     
   let conj n ps =
-    let init = fun () -> List.init n (fun _ -> N.any ()) in
+    let init = fun () -> List.init n (fun _ -> Tdefs.any_node) in
     mapn init N.conj ps
   let disj n ps =
-    let init = fun () -> List.init n (fun _ -> N.empty ()) in
+    let init = fun () -> List.init n (fun _ -> Tdefs.empty_node) in
     mapn init N.disj ps
 
   let rec distribute_diff ss tt =
@@ -95,13 +93,13 @@ module MakeC(N:Node) = struct
 
     let to_t a = [a], []
     let to_t' (ns,b) =
-      let any_tuple n = List.init n (fun _ -> N.any()) in
+      let any_tuple n = List.init n (fun _ -> Tdefs.any_node) in
       let rec aux ns =
         match ns with
         | [] -> []
         | n::ns ->
           let this = (N.neg n)::(any_tuple (List.length ns)) in
-          let others = aux ns |> List.map (fun s -> (N.any())::s) in
+          let others = aux ns |> List.map (fun s -> Tdefs.any_node::s) in
           this::others
       in
       if b then [ns] else aux ns
@@ -114,7 +112,7 @@ module MakeC(N:Node) = struct
   module Dnf = Dnf.Make(DnfAtom)(N)
 
   let dnf (_,t) = Bdd.dnf t |> Dnf.mk
-  let dnf' (n,t) = dnf (n,t) |> Dnf'.from_dnf (List.init n (fun _ -> N.any ()))
+  let dnf' (n,t) = dnf (n,t) |> Dnf'.from_dnf (List.init n (fun _ -> Tdefs.any_node))
   let of_dnf tag dnf =
     dnf |> List.iter (fun (ps,ns,_) ->
       ps |> List.iter (fun a -> check_tag tag (Atom.tag a)) ;

--- a/src/core/descr.ml
+++ b/src/core/descr.ml
@@ -17,33 +17,11 @@ module Make(N:Node) = struct
     | Tags of Tags.t
     | Tuples of Tuples.t
 
-  type t = {
-    atoms : Atoms.t ;
-    tags : Tags.t ;
-    tuples : Tuples.t ;
-    arrows : Arrows.t ;
-    records : Records.t ;
-    intervals : Intervals.t
-  }
+  type t = Tdefs.descr
   type node = N.t
 
-  let any = {
-    atoms = Atoms.any ;
-    tags = Tags.any  ;
-    tuples = Tuples.any ;
-    arrows = Arrows.any ;
-    records = Records.any ;
-    intervals = Intervals.any
-  }
-
-  let empty = {
-    atoms = Atoms.empty ;
-    tags = Tags.empty;
-    tuples = Tuples.empty;
-    arrows = Arrows.empty;
-    records = Records.empty;
-    intervals = Intervals.empty
-  }
+  let empty = Tdefs.empty_descr
+  let any = Tdefs.any_descr
 
   let mk_atoms a = { empty with atoms = a }
   let mk_tags a = { empty with tags = a }
@@ -61,44 +39,44 @@ module Make(N:Node) = struct
   let mk_record a = Records.mk a |> mk_records
   let mk_interval a = Intervals.mk a |> mk_intervals
 
-  let get_atoms t = t.atoms
-  let get_tags t = t.tags
-  let get_arrows t = t.arrows
-  let get_tuples t = t.tuples
-  let get_records t = t.records
-  let get_intervals t = t.intervals
+  let get_atoms t = t.Tdefs.atoms
+  let get_tags t = t.Tdefs.tags
+  let get_arrows t = t.Tdefs.arrows
+  let get_tuples t = t.Tdefs.tuples
+  let get_records t = t.Tdefs.records
+  let get_intervals t = t.Tdefs.intervals
 
   let components t =
-    [ Atoms t.atoms ; Arrows t.arrows ; Intervals t.intervals ;
-      Tags t.tags ; Tuples t.tuples ; Records t.records ]
+    Tdefs.[ Atoms t.atoms ; Arrows t.arrows ; Intervals t.intervals ;
+            Tags t.tags ; Tuples t.tuples ; Records t.records ]
   let set_component t comp =
     match comp with
-    | Atoms atoms -> { t with atoms }
-    | Arrows arrows -> { t with arrows }
-    | Intervals intervals -> { t with intervals }
-    | Tags tags -> { t with tags }
-    | Tuples tuples -> { t with tuples }
-    | Records records -> { t with records }
+    | Atoms atoms -> { t with Tdefs.atoms }
+    | Arrows arrows -> { t with Tdefs.arrows }
+    | Intervals intervals -> { t with Tdefs.intervals }
+    | Tags tags -> { t with Tdefs.tags }
+    | Tuples tuples -> { t with Tdefs.tuples }
+    | Records records -> { t with Tdefs.records }
   let of_component = set_component empty
   let of_components = List.fold_left set_component empty
 
-  let unop fato ftag ftup farr frec fint t = {
-    atoms = fato t.atoms ;
-    tags = ftag t.tags ;
-    tuples = ftup t.tuples ;
-    arrows = farr t.arrows ;
-    records = frec t.records ;
-    intervals = fint t.intervals
-  }
+  let unop fato ftag ftup farr frec fint t = Tdefs.{
+      atoms = fato t.atoms ;
+      tags = ftag t.tags ;
+      tuples = ftup t.tuples ;
+      arrows = farr t.arrows ;
+      records = frec t.records ;
+      intervals = fint t.intervals
+    }
 
-  let binop fato ftag ftup farr frec fint t1 t2 = {
-    atoms = fato t1.atoms t2.atoms ;
-    tags = ftag t1.tags t2.tags ;
-    tuples = ftup t1.tuples t2.tuples ;
-    arrows = farr t1.arrows t2.arrows ;
-    records = frec t1.records t2.records ;
-    intervals = fint t1.intervals t2.intervals
-  }
+  let binop fato ftag ftup farr frec fint t1 t2 = Tdefs.{
+      atoms = fato t1.atoms t2.atoms ;
+      tags = ftag t1.tags t2.tags ;
+      tuples = ftup t1.tuples t2.tuples ;
+      arrows = farr t1.arrows t2.arrows ;
+      records = frec t1.records t2.records ;
+      intervals = fint t1.intervals t2.intervals
+    }
 
   let cap = binop Atoms.cap Tags.cap Tuples.cap Arrows.cap Records.cap Intervals.cap
   let cup = binop Atoms.cup Tags.cup Tuples.cup Arrows.cup Records.cup Intervals.cup
@@ -106,6 +84,7 @@ module Make(N:Node) = struct
   let neg = unop Atoms.neg Tags.neg Tuples.neg Arrows.neg Records.neg Intervals.neg
 
   let is_empty t =
+    let open Tdefs in
     Atoms.is_empty t.atoms &&
     Intervals.is_empty t.intervals &&
     Tags.is_empty t.tags &&
@@ -114,13 +93,13 @@ module Make(N:Node) = struct
     Records.is_empty t.records
 
   let direct_nodes t =
-    [ Atoms.direct_nodes t.atoms ;
-      Tags.direct_nodes t.tags ;
-      Tuples.direct_nodes t.tuples ;
-      Arrows.direct_nodes t.arrows ;
-      Records.direct_nodes t.records ;
-      Intervals.direct_nodes t.intervals
-    ] |> List.concat
+    Tdefs.[ Atoms.direct_nodes t.atoms ;
+            Tags.direct_nodes t.tags ;
+            Tuples.direct_nodes t.tuples ;
+            Arrows.direct_nodes t.arrows ;
+            Records.direct_nodes t.records ;
+            Intervals.direct_nodes t.intervals
+          ] |> List.concat
 
   let simplify = unop Atoms.simplify Tags.simplify Tuples.simplify
       Arrows.simplify Records.simplify Intervals.simplify
@@ -128,6 +107,7 @@ module Make(N:Node) = struct
       (Arrows.map_nodes f) (Records.map_nodes f) (Intervals.map_nodes f)
 
   let compare t1 t2 =
+    let open Tdefs in
     Atoms.compare t1.atoms t2.atoms |> ccmp
       Intervals.compare t1.intervals t2.intervals |> ccmp
       Tags.compare t1.tags t2.tags |> ccmp
@@ -136,6 +116,7 @@ module Make(N:Node) = struct
       Records.compare t1.records t2.records
 
   let equal t1 t2 =
+    let open Tdefs in
     Atoms.equal t1.atoms t2.atoms &&
     Intervals.equal t1.intervals t2.intervals &&
     Tags.equal t1.tags t2.tags &&

--- a/src/core/descr.ml
+++ b/src/core/descr.ml
@@ -3,19 +3,19 @@ open Sstt_utils
 
 module Make(N:Node) = struct
   module Arrows = Arrows.Make(N)
-  module Atoms = Atoms.Make(N)
-  module Intervals = Intervals.Make(N)
+  module Atoms = Atoms
+  module Intervals = Intervals
   module Records = Records.Make(N)
   module Tags = Tags.Make(N)
   module Tuples = Tuples.Make(N)
 
   type component =
-  | Atoms of Atoms.t
-  | Arrows of Arrows.t
-  | Intervals of Intervals.t
-  | Records of Records.t
-  | Tags of Tags.t
-  | Tuples of Tuples.t
+    | Atoms of Atoms.t
+    | Arrows of Arrows.t
+    | Intervals of Intervals.t
+    | Records of Records.t
+    | Tags of Tags.t
+    | Tuples of Tuples.t
 
   type t = {
     atoms : Atoms.t ;
@@ -123,17 +123,17 @@ module Make(N:Node) = struct
     ] |> List.concat
 
   let simplify = unop Atoms.simplify Tags.simplify Tuples.simplify
-    Arrows.simplify Records.simplify Intervals.simplify
+      Arrows.simplify Records.simplify Intervals.simplify
   let map_nodes f = unop (Atoms.map_nodes f) (Tags.map_nodes f) (Tuples.map_nodes f)
-    (Arrows.map_nodes f) (Records.map_nodes f) (Intervals.map_nodes f)
+      (Arrows.map_nodes f) (Records.map_nodes f) (Intervals.map_nodes f)
 
   let compare t1 t2 =
     Atoms.compare t1.atoms t2.atoms |> ccmp
-    Intervals.compare t1.intervals t2.intervals |> ccmp
-    Tags.compare t1.tags t2.tags |> ccmp
-    Tuples.compare t1.tuples t2.tuples |> ccmp
-    Arrows.compare t1.arrows t2.arrows |> ccmp
-    Records.compare t1.records t2.records
+      Intervals.compare t1.intervals t2.intervals |> ccmp
+      Tags.compare t1.tags t2.tags |> ccmp
+      Tuples.compare t1.tuples t2.tuples |> ccmp
+      Arrows.compare t1.arrows t2.arrows |> ccmp
+      Records.compare t1.records t2.records
 
   let equal t1 t2 =
     Atoms.equal t1.atoms t2.atoms &&

--- a/src/core/node.ml
+++ b/src/core/node.ml
@@ -3,7 +3,7 @@ open Sigs
 open Effect.Deep
 open Effect
 
-module rec Node : Node with type vdescr = VDescr.t and type descr = VDescr.Descr.t = struct
+module rec Node : Node = struct
 
   module NSet = Set.Make(Node)
   module NMap = Map.Make(Node)
@@ -11,49 +11,11 @@ module rec Node : Node with type vdescr = VDescr.t and type descr = VDescr.Descr
   type _ Effect.t += GetCache: unit -> (bool VDMap.t) t
   type _ Effect.t += SetCache: bool VDMap.t -> unit t
 
-  type vdescr = VDescr.t
-  type descr = VDescr.Descr.t
-
-  type t = {
-    id : int ;
-    neg : t ; (* Always generate the negation node as it is very easy to compute *)
-    mutable def : VDescr.t option ;
-    mutable simplified : bool ;
-  }
-  type node = t
-
-  let has_def t = Option.is_some t.def
-  let def t = t.def |> Option.get
-
-  let hash t = Hashtbl.hash t.id
-  let compare t1 t2 = compare t1.id t2.id
-  let equal t1 t2 = (t1.id = t2.id)
-
-  let next_id =
-    let c = ref 0 in
-    fun () -> c := !c + 1 ; !c
-
-  let mk () =
-    let rec t =
-      {
-        id = next_id () ;
-        def = None ;
-        simplified = false ;
-        neg = {
-          id = next_id () ;
-          def = None ;
-          simplified = false ;
-          neg = t
-        }
-      }
-    in
-    t
+  include Tdefs.N
 
   let define ?(simplified=false) t d =
-    t.def <- Some d ;
-    if simplified then t.simplified <- true ;
-    t.neg.def <- Some (VDescr.neg d) ;
-    if simplified then t.neg.simplified <- true
+    let n = VDescr.neg d in
+    define simplified t d n
 
   let cons d =
     let t = mk () in
@@ -61,44 +23,47 @@ module rec Node : Node with type vdescr = VDescr.t and type descr = VDescr.Descr
 
   let of_def d = d |> cons
 
-  let any, empty =
-    let any =  VDescr.any |> cons in
-    let empty = any.neg in
-    (fun () -> any), (fun () -> empty)
-
   let cap t1 t2 =
     VDescr.cap (def t1) (def t2) |> cons
+
   let cup t1 t2 =
     VDescr.cup (def t1) (def t2) |> cons
-  let neg t = t.neg
+
+
   let diff t1 t2 =
     VDescr.diff (def t1) (def t2) |> cons
-  let conj ts = List.fold_left cap (any ()) ts
-  let disj ts = List.fold_left cup (empty ()) ts
+
+  let conj ts = List.fold_left cap Tdefs.any_node ts
+  let disj ts = List.fold_left cup Tdefs.empty_node ts
 
   let is_empty t =
     let def = def t in
-    if t.simplified then
-      VDescr.equal def VDescr.empty
+    if is_simplified t then
+      VDescr.equal def Tdefs.empty_vdescr
     else
       let cache = perform (GetCache ()) in
       begin match VDMap.find_opt def cache with
-      | Some b -> b
-      | None ->
-        let cache' = ref (VDMap.add def true cache) in
-        let b =
-          match VDescr.is_empty def with
-          | b -> b
-          | effect GetCache (), k -> continue k !cache'
-          | effect SetCache c, k -> cache' := c ; continue k ()
-        in
-        let cache = if b then !cache' else VDMap.add def false cache in
-        perform (SetCache (VDMap.add def b cache)) ; b
+        | Some b -> b
+        | None ->
+          let cache' = ref (VDMap.add def true cache) in
+          let b =
+            match VDescr.is_empty def with
+            | b -> b
+            | effect GetCache (), k -> continue k !cache'
+            | effect SetCache c, k -> cache' := c ; continue k ()
+          in
+          let cache = if b then !cache' else VDMap.add def false cache in
+          perform (SetCache (VDMap.add def b cache)) ; b
       end
+
   let leq t1 t2 = diff t1 t2 |> is_empty
+
   let equiv t1 t2 = leq t1 t2 && leq t2 t1
+
   let is_any t = neg t |> is_empty
+
   let disjoint t1 t2 = cap t1 t2 |> is_empty
+
   let with_own_cache f t =
     let cache = ref VDMap.empty in
     match f t with
@@ -107,7 +72,7 @@ module rec Node : Node with type vdescr = VDescr.t and type descr = VDescr.Descr
     | effect SetCache c, k -> cache := c ; continue k ()
 
   let rec simplify t =
-    if not t.simplified then begin
+    if not (is_simplified t) then begin
       define ~simplified:true t (def t |> VDescr.simplify) ;
       def t |> VDescr.direct_nodes |> List.iter simplify
     end
@@ -116,27 +81,28 @@ module rec Node : Node with type vdescr = VDescr.t and type descr = VDescr.Descr
     let direct_nodes t = def t |> VDescr.direct_nodes |> NSet.of_list in
     let rec aux ts =
       let ts' = ts
-      |> NSet.to_list
-      |> List.map direct_nodes
-      |> List.fold_left NSet.union ts
+                |> NSet.to_list
+                |> List.map direct_nodes
+                |> List.fold_left NSet.union ts
       in
       if NSet.equal ts ts' then ts' else aux ts'
     in
     aux (NSet.singleton t)
 
   let vars_toplevel t = def t |> VDescr.direct_vars |> VarSet.of_list
+
   let vars t =
     dependencies t |> NSet.to_list |> List.map vars_toplevel
     |> List.fold_left VarSet.union VarSet.empty
 
   let of_eqs eqs =
     let deps = List.map snd eqs |> List.map dependencies
-    |> List.fold_left NSet.union NSet.empty in
+               |> List.fold_left NSet.union NSet.empty in
     let copies = NSet.to_list deps |>
-      List.fold_left (fun acc n -> NMap.add n (mk ()) acc) NMap.empty in
+                 List.fold_left (fun acc n -> NMap.add n (mk ()) acc) NMap.empty in
     let new_node n =
       match eqs |> List.find_opt (fun (v,_) ->
-        VDescr.equal (VDescr.mk_var v) (def n)) with
+          VDescr.equal (VDescr.mk_var v) (def n)) with
       | None -> NMap.find n copies
       | Some (_,n) -> NMap.find n copies (* Optimisation to avoid introducing a useless node *)
     in
@@ -145,8 +111,8 @@ module rec Node : Node with type vdescr = VDescr.t and type descr = VDescr.Descr
         let deps_ok n =
           let vs = vars_toplevel n in
           eqs |> List.for_all (fun (v,n) ->
-            VarSet.mem v vs |> not || new_node n |> has_def
-          )
+              VarSet.mem v vs |> not || new_node n |> has_def
+            )
         in
         match NSet.elements deps |> List.find_opt deps_ok with
         | None -> raise (Invalid_argument "Set of equations is not contractive.")
@@ -154,9 +120,9 @@ module rec Node : Node with type vdescr = VDescr.t and type descr = VDescr.Descr
           let nn = new_node n in
           if has_def nn |> not then begin
             let s = eqs |> List.filter_map (fun (v,n) ->
-              let nn = new_node n in
-              if has_def nn then Some (v, def nn) else None
-            ) |> VarMap.of_list in
+                let nn = new_node n in
+                if has_def nn then Some (v, def nn) else None
+              ) |> VarMap.of_list in
             let d = def n |> VDescr.map_nodes new_node |> VDescr.substitute s in
             define nn d
           end ;
@@ -171,7 +137,7 @@ module rec Node : Node with type vdescr = VDescr.t and type descr = VDescr.Descr
     (* Optimisation: reuse nodes if possible *)
     let unchanged n = VarSet.disjoint (vars n) dom in
     let deps = dependencies t |> NSet.to_list
-      |> List.filter (fun n -> unchanged n |> not) in
+               |> List.filter (fun n -> unchanged n |> not) in
     let copies = List.fold_left (fun acc n -> NMap.add n (mk ()) acc) NMap.empty deps in
     let new_node n =
       match NMap.find_opt n copies with
@@ -179,14 +145,15 @@ module rec Node : Node with type vdescr = VDescr.t and type descr = VDescr.Descr
       | None -> n
     in
     deps |> List.iter (fun n ->
-      let d = def n |> VDescr.map_nodes new_node |> VDescr.substitute s in
-      define (new_node n) d
-    ) ;
+        let d = def n |> VDescr.map_nodes new_node |> VDescr.substitute s in
+        define (new_node n) d
+      ) ;
     new_node t
 
   let mk_var v = VDescr.mk_var v |> cons
   let mk_descr d = VDescr.mk_descr d |> cons
   let get_descr t = def t |> VDescr.get_descr
   let nodes t = dependencies t |> NSet.to_list
+
 end
-and VDescr : VDescr with type node = Node.t = Vdescr.Make(Node)
+and VDescr : VDescr = Vdescr.Make(Node)

--- a/src/core/sigs.ml
+++ b/src/core/sigs.ml
@@ -6,25 +6,14 @@ module type Comparable = sig
   val equal : t -> t -> bool
 end
 
+
 module type TyBase = sig
   type t
-  type node
-
-  val any : t
   val empty : t
+  val any : t
 
-  include Comparable with type t := t
 end
 
-module type TyBaseRef = sig
-  type t
-  type node
-
-  val any : unit -> t
-  val empty : unit -> t
-
-  include Comparable with type t := t
-end
 
 module type SetTheoretic = sig
   type t
@@ -75,11 +64,11 @@ end
 
 (* Atoms *)
 
-module type AtomAtom = Id.NamedIdentifier
-
 module type Atoms = sig
-  include TyBase
-  module Atom : AtomAtom
+  include TyBase with type t = Tdefs.atoms
+  include Comparable with type t := t
+
+  module Atom = Atoms.Atom
   val mk : Atom.t -> t
 
   val construct : bool * Atom.t list -> t
@@ -93,6 +82,7 @@ end
 (* Intervals *)
 
 module type IntervalAtom = sig
+  (* TODO: Unused, remove and put the doc string elsewhere *)
   (** [t] represents a non-empty integer interval. *)
   type t
 
@@ -118,8 +108,10 @@ module type IntervalAtom = sig
 end
 
 module type Intervals = sig
-  include TyBase
-  module Atom : IntervalAtom
+  include TyBase with type t = Tdefs.intervals
+  include Comparable with type t := t
+
+  module Atom = Intervals.Atom
   val mk : Atom.t -> t
   val construct : Atom.t list -> t
   val destruct : t -> Atom.t list
@@ -134,15 +126,20 @@ end
 (* Arrows *)
 
 module type ArrowAtom = sig
-  type node
-  type t = node * node
-  include Comparable with type t := t
-  val map_nodes : (node -> node) -> t -> t
+
+  include Comparable with  type t = Tdefs.arrow_atom
+
+  val map_nodes : (Tdefs.node -> Tdefs.node) -> t -> t
 end
 
 module type Arrows = sig
-  include TyBase
-  module Atom : ArrowAtom with type node := node
+  include TyBase with type t = Tdefs.arrows
+  include Comparable with type t := t
+
+
+  include Comparable with type t = Tdefs.arrows
+
+  module Atom : ArrowAtom
   module Dnf : Dnf with type atom = Atom.t and type leaf = bool
   val mk : Atom.t -> t
 
@@ -152,18 +149,14 @@ module type Arrows = sig
   val of_dnf : Dnf.t -> t
 
   (** [map_nodes f t] replaces every node [n] in [t] by the node [f n]. *)
-  val map_nodes : (node -> node) -> t -> t
+  val map_nodes : (Tdefs.node -> Tdefs.node) -> t -> t
 end
 
 (* Records *)
 
-type 'node oty = 'node * bool
-
 module type RecordAtom = sig
-  type node
-  type nonrec oty = node oty
-
-  type t = { bindings : oty LabelMap.t ; opened : bool }
+  type t = Tdefs.record_atom = { bindings : Tdefs.onode LabelMap.t ; opened : bool }
+  include Comparable with type t := t
 
   (** [dom t] returns the set of explicit labels in [t].
       Note that this does not mean that labels in [dom t] are present in
@@ -173,21 +166,18 @@ module type RecordAtom = sig
 
   (** [find l t] returns the type associated with the label [l] in [t],
       even if [t] does not have an explicit binding for [l]. *)
-  val find : Label.t -> t -> oty
-
-  val to_tuple : Label.t list -> t -> oty list
-  val to_tuple_with_default : Label.t list -> t -> oty list
-  include Comparable with type t := t
-  val map_nodes : (node -> node) -> t -> t
+  val find : Label.t -> t -> Tdefs.onode
+  val to_tuple : Label.t list -> t -> Tdefs.onode list
+  val to_tuple_with_default : Label.t list -> t -> Tdefs.onode list
+  val map_nodes : (Tdefs.node -> Tdefs.node) -> t -> t
 end
 
 module type RecordAtom' = sig
-  type node
-  type nonrec oty = node oty
 
   (** When the field [required] is equal to [Some labels],
       it means that [t] requires at least one field not in [labels] to be present. *)
-  type t = { bindings : oty LabelMap.t ; opened : bool ; required : LabelSet.t option }
+  type t = Tdefs.record_atom' = { bindings : Tdefs.onode LabelMap.t ; opened : bool; required : LabelSet.t option }
+  include Comparable with type t := t
 
   (** [dom t] returns the set of explicit labels in [t].
       Note that this does not mean that labels in [dom t] are present in
@@ -197,15 +187,16 @@ module type RecordAtom' = sig
 
   (** [find l t] returns the type associated with the label [l] in [t],
       even if [t] does not have an explicit binding for [l]. *)
-  val find : Label.t -> t -> oty
+  val find : Label.t -> t -> Tdefs.onode
 
-  include Comparable with type t := t
 end
 
 module type Records = sig
-  include TyBase
-  module Atom : RecordAtom with type node := node
-  module Atom' : RecordAtom' with type node := node
+  include TyBase with type t = Tdefs.records 
+  include Comparable with type t := t
+
+  module Atom : RecordAtom
+  module Atom' : RecordAtom'
   module Dnf : Dnf with type atom = Atom.t and type leaf = bool
   module Dnf' : Dnf' with type atom = Atom'.t and type leaf = bool
   val mk : Atom.t -> t
@@ -221,21 +212,21 @@ module type Records = sig
   val of_dnf' : Dnf'.t -> t
 
   (** [map_nodes f t] replaces every node [n] in [t] by the node [f n]. *)
-  val map_nodes : (node -> node) -> t -> t
+  val map_nodes : (Tdefs.node -> Tdefs.node) -> t -> t
 end
 
 (* Tuples *)
 
 module type TupleAtom = sig
-  type node
-  type t = node list
+  type t = Tdefs.tuple_atom
   include Comparable with type t := t
-  val map_nodes : (node -> node) -> t -> t
+  val map_nodes : (Tdefs.node -> Tdefs.node) -> t -> t
 end
 
 module type TupleComp = sig
-  include TyBase
-  module Atom : TupleAtom with type node := node
+  include Comparable with type t = Tdefs.tuple_comp
+
+  module Atom : TupleAtom
   module Dnf : Dnf with type atom = Atom.t and type leaf = bool
   module Dnf' : Dnf' with type atom = Atom.t and type leaf = bool
   val any : int -> t
@@ -256,12 +247,14 @@ module type TupleComp = sig
   val of_dnf' : int -> Dnf'.t -> t
 
   (** [map_nodes f t] replaces every node [n] in [t] by the node [f n]. *)
-  val map_nodes : (node -> node) -> t -> t
+  val map_nodes : (Tdefs.node -> Tdefs.node) -> t -> t
 end
 
 module type Tuples = sig
-  include TyBase
-  module TupleComp : TupleComp with type node := node
+  include TyBase with type t = Tdefs.tuples
+  include Comparable with type t := t
+
+  module TupleComp : TupleComp
   val mk : TupleComp.Atom.t -> t
   val mk_comp : TupleComp.t -> t
 
@@ -287,22 +280,21 @@ module type Tuples = sig
   val destruct : t -> bool * TupleComp.t list
 
   (** [map_nodes f t] replaces every node [n] in [t] by the node [f n]. *)
-  val map_nodes : (node -> node) -> t -> t
+  val map_nodes : (Tdefs.node -> Tdefs.node) -> t -> t
 end
 
 (* Tags *)
 
 module type TagAtom = sig
-  type node
-  module Tag : Id.NamedIdentifier
-  type t = Tag.t * node
+  module Tag = Tdefs.Tag
+  type t = Tdefs.tag_atom
   include Comparable with type t := t
-  val map_nodes : (node -> node) -> t -> t
+  val map_nodes : (Tdefs.node -> Tdefs.node) -> t -> t
 end
 
 module type TagComp = sig
-  include TyBase
-  module Atom : TagAtom with type node := node
+  include Comparable with type t = Tdefs.tag_comp
+  module Atom : TagAtom
   module Tag = Atom.Tag
   module Dnf : Dnf with type atom = Atom.t and type leaf = bool
   val any : Tag.t -> t
@@ -321,12 +313,16 @@ module type TagComp = sig
   val as_atom : t -> Atom.t
 
   (** [map_nodes f t] replaces every node [n] in [t] by the node [f n]. *)
-  val map_nodes : (node -> node) -> t -> t
+  val map_nodes : (Tdefs.node -> Tdefs.node) -> t -> t
 end
 
 module type Tags = sig
-  include TyBase
-  module TagComp : TagComp with type node := node
+  include TyBase with type t = Tdefs.tags
+  include Comparable with type t := t
+
+  module TagComp : TagComp
+  module TMap : Map.S with type key = TagComp.Tag.t
+
   val mk : TagComp.Atom.t -> t
   val mk_comp : TagComp.t -> t
 
@@ -352,20 +348,21 @@ module type Tags = sig
   val destruct : t -> bool * TagComp.t list
 
   (** [map_nodes f t] replaces every node [n] in [t] by the node [f n]. *)
-  val map_nodes : (node -> node) -> t -> t
+  val map_nodes : (Tdefs.node -> Tdefs.node) -> t -> t
 end
 
 (* Descr *)
 
 module type Descr = sig
-  include TyBase
+  include TyBase with type t = Tdefs.descr
+  include Comparable with type t := t
 
-  module Arrows : Arrows with type node := node
-  module Atoms : Atoms with type node := node
-  module Intervals : Intervals with type node := node
-  module Records : Records with type node := node
-  module Tags : Tags with type node := node
-  module Tuples : Tuples with type node := node
+  module Arrows : Arrows
+  module Atoms : Atoms
+  module Intervals : Intervals
+  module Records : Records
+  module Tags : Tags
+  module Tuples : Tuples
 
   type component =
     | Atoms of Atoms.t
@@ -374,6 +371,9 @@ module type Descr = sig
     | Records of Records.t
     | Tags of Tags.t
     | Tuples of Tuples.t
+
+  val any : t 
+  val empty : t
 
   val mk_atom : Atoms.Atom.t -> t
   val mk_atoms : Atoms.t -> t
@@ -403,13 +403,14 @@ module type Descr = sig
   val of_components : component list -> t
 
   (** [map_nodes f t] replaces every node [n] in [t] by the node [f n]. *)
-  val map_nodes : (node -> node) -> t -> t
+  val map_nodes : (Tdefs.node -> Tdefs.node) -> t -> t
 end
 
 (* VDescr *)
 
 module type VDescr = sig
-  include TyBase
+  include TyBase with type t = Tdefs.vdescr
+  include Comparable with type t := t
 
   val cap : t -> t -> t
   val cup : t -> t -> t
@@ -419,30 +420,29 @@ module type VDescr = sig
   val leq : t -> t -> bool
   val equiv : t -> t -> bool
 
-
-  module Descr : Descr with type node := node
-  module Dnf : Dnf with type atom = Var.t and type leaf = Descr.t
+  module Descr : Descr
+  module Dnf : Dnf with type atom = Var.t and type leaf = Tdefs.descr
 
   val mk_var : Var.t -> t
 
   (** [mk_descr d] creates a full descriptor from the monomorphic descriptor [d]. *)
-  val mk_descr : Descr.t -> t
+  val mk_descr : Tdefs.descr -> t
 
   (** [get_descr t] extracts a monomorphic descriptor from [t],
       which describes [t] by ignoring its top-level type variables. *)
-  val get_descr : t -> Descr.t
+  val get_descr : t -> Tdefs.descr
 
   (** [map f t] replaces every descriptor [d] in [t] by the descriptor [f d]. *)
-  val map : (Descr.t -> Descr.t) -> t -> t
+  val map : (Tdefs.descr -> Tdefs.descr) -> t -> t
 
   (** [map_nodes f t] replaces every node [n] in [t] by the node [f n]. *)
-  val map_nodes : (node -> node) -> t -> t
+  val map_nodes : (Tdefs.node -> Tdefs.node) -> t -> t
 
   val dnf : t -> Dnf.t
   val of_dnf : Dnf.t -> t
 
   val simplify : t -> t
-  val direct_nodes : t -> node list
+  val direct_nodes : t -> Tdefs.node list
   val direct_vars : t -> Var.t list
 
   val substitute : t VarMap.t -> t -> t
@@ -451,21 +451,17 @@ end
 (* Nodes *)
 
 module type Node = sig
-  type t
-  type node = t
-  type vdescr
-  type descr
 
-  include TyBaseRef with type t := t and type node := node
+  include Comparable with type t = Tdefs.node
+  include SetTheoretic with type t := t
 
-  val def : t -> vdescr
-  val of_def : vdescr -> t
+  val def : t -> Tdefs.vdescr
+  val of_def : Tdefs.vdescr -> t
 
   val mk_var : Var.t -> t
-  val mk_descr : descr -> t
-  val get_descr : t -> descr
+  val mk_descr : Tdefs.descr -> t
+  val get_descr : t -> Tdefs.descr
 
-  include SetTheoretic with type t := t
   val with_own_cache : ('a -> 'b) -> 'a -> 'b
 
   val vars : t -> VarSet.t
@@ -482,44 +478,37 @@ end
 (* Ty *)
 
 module type Ty = sig
-  type t
-  include TyBase with type t:=t and type node:=t
-
-  module VDescr : VDescr with type node := t
+  include TyBase with type t = Tdefs.node
+  include Comparable with type t := t
 
   module O : sig
-    type node = t
-    type t = node oty
-    include TyBase with type node := node and type t := t
-    val absent : t
-    val required : node -> t
-    val optional : node -> t
-
+    include TyBase with type t = Tdefs.onode 
+    include Comparable with type t := t
     include SetTheoretic with type t := t
+    val absent : t
+    val required : Tdefs.node -> t
+    val optional : Tdefs.node -> t    
     val is_absent : t -> bool
     val is_required : t -> bool
     val is_optional : t -> bool
   end
 
-  val any : t
-  val empty : t
-
   (** [def t] returns the full descriptor of [t]. For a given type [t],
       [def t] is not necessarily constant: it may change over time, for instance
       when the descriptor of [t] is simplified. *)
-  val def : t -> VDescr.t
+  val def : t -> Tdefs.vdescr
 
   (** [of_def d] creates a type from the full descriptor [d]. *)
-  val of_def : VDescr.t -> t
+  val of_def : Tdefs.vdescr -> t
 
   val mk_var : Var.t -> t
 
   (** [mk_descr d] creates a type from the monomorphic descriptor [d]. *)
-  val mk_descr : VDescr.Descr.t -> t
+  val mk_descr : Tdefs.descr -> t
 
   (** [get_descr t] extracts a monomorphic descriptor from [t],
       which describes [t] by ignoring its top-level type variables. *)
-  val get_descr : t -> VDescr.Descr.t
+  val get_descr : t -> Tdefs.descr
 
   include SetTheoretic with type t := t
 

--- a/src/core/sstt_core.ml
+++ b/src/core/sstt_core.ml
@@ -11,14 +11,18 @@ module Ty : Ty = struct
   module VDescr = Node.VDescr
   module O = struct
     include Records.OTy(N)
-    let any, empty, absent = any (), empty (), absent ()
+    let any = Tdefs.any_onode
+    let empty = Tdefs.empty_onode
+    let absent = Tdefs.absent_onode
   end
 
   let simpl t = N.with_own_cache N.simplify t ; t
   let s f t = f t |> simpl
   let s' f t = simpl t |> f
 
-  let any, empty = N.any ()|> simpl, N.empty ()|> simpl
+  let any = Tdefs.any_node
+  let empty = Tdefs.empty_node
+
   let def, of_def = s' N.def, s N.of_def
 
   let mk_var, mk_descr, get_descr = s N.mk_var, s N.mk_descr, s' N.get_descr
@@ -42,7 +46,13 @@ module Ty : Ty = struct
 
   let compare, equal, hash = N.compare, N.equal, N.hash
 end
-module VDescr = Ty.VDescr
+
+module VDescr = struct
+  include Node.VDescr
+  let empty = Tdefs.empty_vdescr
+  let any = Tdefs.any_vdescr
+end
+
 module Descr = VDescr.Descr
 module Arrows = Descr.Arrows
 module Atoms = Descr.Atoms

--- a/src/core/tdefs.ml
+++ b/src/core/tdefs.ml
@@ -1,0 +1,118 @@
+open Base
+
+module Tag = Id.NamedIdentifier()
+module TagMap = Map.Make (Tag)
+module IntMap = Map.Make (Int)
+
+type node = {
+  id : int ;
+  neg : node ;
+  mutable def : vdescr option ;
+  mutable simplified : bool ;
+}
+
+and vdescr = (Var.t, descr) Bdd.t
+
+and descr = {
+  atoms : atoms;
+  intervals : intervals;
+  arrows : arrows;
+  records : records;
+  tuples : tuples;
+  tags : tags;
+}
+
+and atoms = Atoms.t
+
+and intervals = Intervals.t
+
+and arrows = (arrow_atom, bool) Bdd.t
+and arrow_atom = node * node
+
+and records = (record_atom, bool) Bdd.t
+and record_atom = { bindings : onode LabelMap.t ; opened : bool }
+and record_atom' = { bindings : onode LabelMap.t ; opened : bool; required : LabelSet.t option }
+and onode = node * bool
+
+and 'map tagged = { map : 'map; others : bool }
+
+and tuples = tuple_comp IntMap.t tagged
+and tuple_comp = int * (tuple_atom, bool) Bdd.t
+and tuple_atom = node list
+
+and tags = tag_comp TagMap.t tagged
+and tag_comp = Tag.t * (tag_atom, bool) Bdd.t
+and tag_atom = Tag.t * node
+
+let empty_descr = {
+  atoms = Atoms.empty;
+  intervals = Intervals.empty;
+  arrows = Bdd.Leaf false;
+  records = Bdd.Leaf false;
+  tuples = {map = IntMap.empty; others = false };
+  tags = { map = TagMap.empty; others = false }
+}
+let any_descr = {
+  atoms = Atoms.any;
+  intervals = Intervals.any;
+  arrows = Bdd.Leaf true;
+  records = Bdd.Leaf true;
+  tuples = {map = IntMap.empty; others = true };
+  tags = { map = TagMap.empty; others = true }
+}
+
+let empty_vdescr : vdescr = Bdd.Leaf empty_descr
+let any_vdescr : vdescr = Bdd.Leaf any_descr
+
+
+module N  = struct
+  type t = node
+
+  let neg n = n.neg
+  let equal n1 n2 = n1.id = n2.id
+  let hash n = Int.hash n.id
+  let compare n1 n2 = Int.compare n1.id n2.id
+
+
+  let next_id =
+    let c = ref (~-1) in
+    fun () -> c := !c + 1 ; !c
+  let mk () =
+    let id1 = next_id () in
+    let id2 = next_id () in
+    let rec t =
+      {
+        id = id1 ;
+        def = None ;
+        simplified = false ;
+        neg = {
+          id = id2 ;
+          def = None ;
+          simplified = false ;
+          neg = t
+        }
+      }
+    in
+    t
+
+  let define simplified t pos neg = 
+    t.def <- Some pos ;
+    if simplified then t.simplified <- true ;
+    t.neg.def <- Some neg ;
+    if simplified then t.neg.simplified <- true
+
+  let has_def t = t.def |> Option.is_some
+  let def t = t.def |> Option.get
+
+  let is_simplified t = t.simplified
+
+end
+
+let empty_node =
+  let t = N.mk () in
+  N.define true t empty_vdescr any_vdescr; t
+let any_node = empty_node.neg
+
+let any_onode = (any_node, true)
+let empty_onode = (empty_node, false)
+let absent_onode = (empty_node, true)

--- a/src/core/tdefs.mli
+++ b/src/core/tdefs.mli
@@ -1,0 +1,74 @@
+module Tag : Id.NamedIdentifier
+module TagMap : sig include module type of Map.Make (Tag) end
+module IntMap : sig include module type of Map.Make (Int) end
+
+type node 
+and vdescr = (Base.Var.t, descr) Bdd.t
+and descr = {
+  atoms : atoms;
+  intervals : intervals;
+  arrows : arrows;
+  records : records;
+  tuples : tuples;
+  tags : tags;
+}
+and atoms = Atoms.t
+
+and intervals = Intervals.t
+
+and arrows = (arrow_atom, bool) Bdd.t
+and arrow_atom = node * node
+
+and records = (record_atom, bool) Bdd.t
+and record_atom =  { bindings : onode Base.LabelMap.t ; opened : bool }
+and record_atom' =  { bindings : onode Base.LabelMap.t ; opened : bool; required : Base.LabelSet.t option }
+and onode = node * bool
+
+and 'map tagged = { map : 'map; others : bool }
+
+and tuples = tuple_comp IntMap.t tagged
+and tuple_comp = int * (tuple_atom, bool) Bdd.t
+and tuple_atom = node list
+
+and tags = tag_comp TagMap.t tagged
+and tag_comp = Tag.t * (tag_atom, bool) Bdd.t
+and tag_atom = Tag.t * node
+
+val empty_descr : descr
+
+val any_descr : descr
+
+val empty_vdescr : vdescr
+
+val any_vdescr : vdescr
+
+val empty_node : node
+
+val any_node : node
+
+val empty_onode : onode
+
+val any_onode : onode
+
+val absent_onode : onode
+
+module N : 
+sig
+  type t = node
+
+  val equal : node -> node -> bool
+  val compare : node -> node -> int
+  val hash : node -> int
+
+  val neg : t -> t
+
+  val mk : unit -> node
+
+  val define : bool -> node -> vdescr -> vdescr -> unit
+
+  val def : node -> vdescr
+  val has_def : node -> bool
+
+  val is_simplified : node -> bool
+
+end

--- a/src/core/utils/bdd.ml
+++ b/src/core/utils/bdd.ml
@@ -33,11 +33,13 @@ module type Atom = sig
   val equal : t -> t -> bool
 end
 
-module Make(N:Atom)(L:Leaf) = struct
-  type t =
-  | Node of N.t * t * t
-  | Leaf of L.t
+type ('atom, 'leaf) t = 
+ | Leaf of 'leaf
+ | Node of 'atom * ('atom, 'leaf) t * ('atom,'leaf) t
 
+module Make(N:Atom)(L:Leaf) = struct
+  type nonrec t = (N.t, L.t) t
+  
   let empty = Leaf (L.empty)
   let any = Leaf (L.any)
 

--- a/src/core/utils/tagged.ml
+++ b/src/core/utils/tagged.ml
@@ -7,7 +7,6 @@ end
 
 module type TaggedComp = sig
   type t
-  type node
   module Tag : Tag
   val any : Tag.t -> t
   val empty : Tag.t -> t
@@ -16,8 +15,8 @@ module type TaggedComp = sig
   val cup : t -> t -> t
   val diff : t -> t -> t
   val neg : t -> t
-  val map_nodes : (node -> node) -> t -> t
-  val direct_nodes : t -> node list
+  val map_nodes : (Tdefs.node -> Tdefs.node) -> t -> t
+  val direct_nodes : t -> Tdefs.node list
   val simplify : t -> t
   val is_empty : t -> bool
   include Comparable with type t := t
@@ -26,26 +25,28 @@ end
 module Make(C : TaggedComp) = struct
   module TMap = Map.Make(C.Tag)
 
-  type t = { map : C.t TMap.t ; others : bool }
+  type nonrec t = C.t TMap.t Tdefs.tagged
+
 
   let mk a =
     let t = C.tag a in
-    { map = TMap.singleton t a ; others = false }
+    Tdefs.{ map = TMap.singleton t a ; others = false }
   let of_components (ts, others) =
     let map = ts |> List.map (fun a -> (C.tag a, a)) |> TMap.of_list in
-    { map ; others }
+    Tdefs.{ map ; others }
   let construct (pos, cs) =
     if pos then
       let map = cs |> List.map (fun a -> (C.tag a, a)) |> TMap.of_list in
-      { map ; others=false }
+      Tdefs.{ map ; others=false }
     else
       let map = cs |> List.map (fun a -> (C.tag a, C.neg a)) |> TMap.of_list in
       { map ; others=true }
 
-  let any = { map = TMap.empty ; others = true }
-  let empty = { map = TMap.empty ; others = false }
+  let any = Tdefs.{ map = TMap.empty ; others = true }
+  let empty = {Tdefs. map = TMap.empty ; others = false }
 
   let cap t1 t2 =
+    let open Tdefs in
     let others = t1.others && t2.others in
     let map = TMap.merge (fun _ o1 o2 ->
         match o1, o2 with
@@ -56,6 +57,7 @@ module Make(C : TaggedComp) = struct
       ) t1.map t2.map in
     { map ; others }
   let cup t1 t2 =
+    let open Tdefs in
     let others = t1.others || t2.others in
     let map = TMap.merge (fun _ o1 o2 ->
         match o1, o2 with
@@ -66,10 +68,12 @@ module Make(C : TaggedComp) = struct
       ) t1.map t2.map in
     { map ; others }
   let neg t =
+    let open Tdefs in
     let others = not t.others in
     let map = TMap.map C.neg t.map in
     { map ; others }
   let diff t1 t2 =
+    let open Tdefs in
     let others = t1.others && not t2.others in
     let map = TMap.merge (fun _ o1 o2 ->
         match o1, o2 with
@@ -81,18 +85,21 @@ module Make(C : TaggedComp) = struct
     { map ; others }
 
   let is_empty t =
+    let open Tdefs in
     not t.others &&
     TMap.for_all (fun _ a -> C.is_empty a) t.map
 
-  let direct_nodes t = t.map |> TMap.bindings |>
+  let direct_nodes t = t.Tdefs.map |> TMap.bindings |>
                        List.map (fun (_,t) -> C.direct_nodes t) |>
                        List.concat
 
   let map_nodes f t =
+    let open Tdefs in
     let map = TMap.map (C.map_nodes f) t.map in
     { map ; others=t.others }
 
   let simplify t =
+    let open Tdefs in
     let t_is_empty t = C.is_empty t in
     let t_is_any t = C.neg t |> C.is_empty in
     let map = TMap.map C.simplify t.map in
@@ -101,29 +108,35 @@ module Make(C : TaggedComp) = struct
     { map ; others = t.others }
 
   let components t =
+    let open Tdefs in
     let cs = TMap.bindings t.map |> List.map snd in
     (cs, t.others)
 
   let destruct t =
+    let open Tdefs in
     if t.others then
       (false, TMap.bindings t.map |> List.map snd |> List.map C.neg)
     else
       (true, TMap.bindings t.map |> List.map snd)
 
   let get tag t =
+    let open Tdefs in
     match TMap.find_opt tag t.map with
     | Some a -> a
     | None when t.others -> C.any tag
     | None -> C.empty tag
 
   let map f t =
+    let open Tdefs in
     let map = TMap.map f t.map in
     { t with map }
 
   let equal t1 t2 =
+    let open Tdefs in
     t1.others = t2.others &&
     TMap.equal C.equal t1.map t2.map
   let compare t1 t2 =
+    let open Tdefs in
     compare t1.others t2.others |> ccmp
       (TMap.compare C.compare) t1.map t2.map
 end

--- a/src/core/utils/tagged.ml
+++ b/src/core/utils/tagged.ml
@@ -23,10 +23,9 @@ module type TaggedComp = sig
   include Comparable with type t := t
 end
 
-module Make(N:Node)(C:TaggedComp with type node = N.t) = struct
+module Make(C : TaggedComp) = struct
   module TMap = Map.Make(C.Tag)
 
-  type node = N.t
   type t = { map : C.t TMap.t ; others : bool }
 
   let mk a =
@@ -42,29 +41,29 @@ module Make(N:Node)(C:TaggedComp with type node = N.t) = struct
     else
       let map = cs |> List.map (fun a -> (C.tag a, C.neg a)) |> TMap.of_list in
       { map ; others=true }
-  
+
   let any = { map = TMap.empty ; others = true }
   let empty = { map = TMap.empty ; others = false }
 
   let cap t1 t2 =
     let others = t1.others && t2.others in
     let map = TMap.merge (fun _ o1 o2 ->
-      match o1, o2 with
-      | None, None -> None
-      | Some t1, None -> if t2.others then Some t1 else None
-      | None, Some t2 -> if t1.others then Some t2 else None
-      | Some t1, Some t2 -> Some (C.cap t1 t2)
-    ) t1.map t2.map in
+        match o1, o2 with
+        | None, None -> None
+        | Some t1, None -> if t2.others then Some t1 else None
+        | None, Some t2 -> if t1.others then Some t2 else None
+        | Some t1, Some t2 -> Some (C.cap t1 t2)
+      ) t1.map t2.map in
     { map ; others }
   let cup t1 t2 =
     let others = t1.others || t2.others in
     let map = TMap.merge (fun _ o1 o2 ->
-      match o1, o2 with
-      | None, None -> None
-      | Some t1, None -> if t2.others then None else Some t1
-      | None, Some t2 -> if t1.others then None else Some t2
-      | Some t1, Some t2 -> Some (C.cup t1 t2)
-    ) t1.map t2.map in
+        match o1, o2 with
+        | None, None -> None
+        | Some t1, None -> if t2.others then None else Some t1
+        | None, Some t2 -> if t1.others then None else Some t2
+        | Some t1, Some t2 -> Some (C.cup t1 t2)
+      ) t1.map t2.map in
     { map ; others }
   let neg t =
     let others = not t.others in
@@ -73,12 +72,12 @@ module Make(N:Node)(C:TaggedComp with type node = N.t) = struct
   let diff t1 t2 =
     let others = t1.others && not t2.others in
     let map = TMap.merge (fun _ o1 o2 ->
-      match o1, o2 with
-      | None, None -> None
-      | Some t1, None -> if not t2.others then Some t1 else None
-      | None, Some t2 -> if t1.others then Some (C.neg t2) else None
-      | Some t1, Some t2 -> Some (C.diff t1 t2)
-    ) t1.map t2.map in
+        match o1, o2 with
+        | None, None -> None
+        | Some t1, None -> if not t2.others then Some t1 else None
+        | None, Some t2 -> if t1.others then Some (C.neg t2) else None
+        | Some t1, Some t2 -> Some (C.diff t1 t2)
+      ) t1.map t2.map in
     { map ; others }
 
   let is_empty t =
@@ -86,8 +85,8 @@ module Make(N:Node)(C:TaggedComp with type node = N.t) = struct
     TMap.for_all (fun _ a -> C.is_empty a) t.map
 
   let direct_nodes t = t.map |> TMap.bindings |>
-    List.map (fun (_,t) -> C.direct_nodes t) |>
-    List.concat
+                       List.map (fun (_,t) -> C.direct_nodes t) |>
+                       List.concat
 
   let map_nodes f t =
     let map = TMap.map (C.map_nodes f) t.map in
@@ -126,5 +125,5 @@ module Make(N:Node)(C:TaggedComp with type node = N.t) = struct
     TMap.equal C.equal t1.map t2.map
   let compare t1 t2 =
     compare t1.others t2.others |> ccmp
-    (TMap.compare C.compare) t1.map t2.map
+      (TMap.compare C.compare) t1.map t2.map
 end


### PR DESCRIPTION
This commit changes the definition of the type algebreaWe define the core type algebra in several layers:
- Bdd type is made parametric in its atoms and leaves, exposing the `Leaf` and `Node` constructor
- module `Tdefs` is introduced. It defines a set of mutually recursive types (not modules) for
node, vdescr, descr, and the components and their atoms.
- module `Tdefs.N` contains the 'node making functions' (`mk`, `def`) and accessors such as
`def`, `is_simplified` and `neg`.
- module `Tdefs` can then define `any/empty` for each components (since those don't contain a node)
then `any/empty_descr` then `any/empty_vdescr` and finaly `any/empty_node`.
- The `Node` module does not contain `any/empty`, it only has functionnal values and is therefore
a safe recursive module
- The other modules use `Tdefs.any_node` and `Tdefs.empty_node` instead of `Node.any/empty`
- The toplevel `Ty` module adds these constants after the cycle is closed.

The other modifications are:
- intervals is no longer a functor
- remove all occurrences of a `type node` in all modules, it is `Tdefs.node`
- add in `Sigs` more type equalities equating types from signatures and the corresponding types
in `Tdefs`.