### PR TITLE
Non invasive optimzations

### DIFF
--- a/src/core/components/arrows.ml
+++ b/src/core/components/arrows.ml
@@ -47,8 +47,7 @@ module Make(N:Node) = struct
     psi_strict t1 (N.neg t2) ps
   let is_clause_empty (ps,ns,b) =
     if b then List.exists (is_clause_empty' ps) ns else true
-  let is_empty t =
-    Bdd.dnf t |> List.for_all is_clause_empty
+  let is_empty t = Bdd.for_all_lines is_clause_empty t
 
   let leq t1 t2 = diff t1 t2 |> is_empty
   let equiv t1 t2 = leq t1 t2 && leq t2 t1
@@ -64,7 +63,7 @@ module Make(N:Node) = struct
   let dnf t = Bdd.dnf t |> Dnf.mk
   let of_dnf dnf = Dnf.mk dnf |> Bdd.of_dnf
 
-  let direct_nodes t = Bdd.atoms t |> List.map Atom.direct_nodes |> List.concat
+  let direct_nodes t = Bdd.atoms t |> List.concat_map Atom.direct_nodes
   let map_nodes f t = Bdd.map_nodes (Atom.map_nodes f) t
 
   let simplify t = Bdd.simplify equiv t

--- a/src/core/components/intervals.ml
+++ b/src/core/components/intervals.ml
@@ -123,7 +123,7 @@ let neg t =
   aux [] (ISet.elements t) |> ISet.of_list
 let cup t1 t2 = ISet.union t1 t2 |> normalize
 let cap t1 t2 =
-  carthesian_product (ISet.elements t1) (ISet.elements t2)
+  cartesian_product (ISet.elements t1) (ISet.elements t2)
   |> List.filter_map (fun (i1, i2) -> Interval.inter i1 i2) |> of_list
 let diff t1 t2 = cap t1 (neg t2)
 

--- a/src/core/components/tags.ml
+++ b/src/core/components/tags.ml
@@ -78,7 +78,7 @@ module MakeC(N:Node) = struct
     let merge_line (ps,ns,_) = ty_of_clause (ps,ns) in
     tag, dnf (tag,t) |> List.map merge_line |> N.disj
 
-  let direct_nodes (_,t) = Bdd.atoms t |> List.map Atom.direct_nodes |> List.concat
+  let direct_nodes (_,t) = Bdd.atoms t |> List.concat_map Atom.direct_nodes
   let map_nodes f (tag,t) = tag, Bdd.map_nodes (Atom.map_nodes f) t
 
   let simplify (tag,t) = (tag,Bdd.simplify equiv t)

--- a/src/core/node.ml
+++ b/src/core/node.ml
@@ -92,7 +92,7 @@ module rec Node : Node with type vdescr = VDescr.t and type descr = VDescr.Descr
           | effect SetCache c, k -> cache' := c ; continue k ()
         in
         let cache = if b then !cache' else VDMap.add def false cache in
-        perform (SetCache (VDMap.add def b cache)) ; b
+        perform (SetCache cache); b
       end
   let leq t1 t2 = diff t1 t2 |> is_empty
   let equiv t1 t2 = leq t1 t2 && leq t2 t1

--- a/src/core/node.ml
+++ b/src/core/node.ml
@@ -1,3 +1,4 @@
+open Sstt_utils
 open Base
 open Sigs
 open Effect.Deep
@@ -64,17 +65,32 @@ module rec Node : Node with type vdescr = VDescr.t and type descr = VDescr.Descr
   let of_def d = d |> cons
 
   let any, empty =
-    let any =  VDescr.any |> cons in
+    let any = VDescr.any |> cons in
     let empty = any.neg in
     (fun () -> any), (fun () -> empty)
 
+  let is_any_ =
+    let any = any () in
+    fun t -> t == any
+  let is_empty_ =
+    let empty = empty () in
+    fun t -> t == empty
   let cap t1 t2 =
-    VDescr.cap (def t1) (def t2) |> cons
+    if is_any_ t1 then t2
+    else if is_any_ t2 then t1
+    else
+      VDescr.cap (def t1) (def t2) |> cons
   let cup t1 t2 =
-    VDescr.cup (def t1) (def t2) |> cons
+    if is_empty_ t1 then t2
+    else if is_empty_ t2 then t1
+    else
+      VDescr.cup (def t1) (def t2) |> cons
   let neg t = t.neg
   let diff t1 t2 =
-    VDescr.diff (def t1) (def t2) |> cons
+    if is_empty_ t1 || is_any_ t2 then empty ()
+    else if is_empty_ t2 then t1
+    else
+      VDescr.diff (def t1) (def t2) |> cons
   let conj ts = List.fold_left cap (any ()) ts
   let disj ts = List.fold_left cup (empty ()) ts
 
@@ -85,17 +101,17 @@ module rec Node : Node with type vdescr = VDescr.t and type descr = VDescr.Descr
     else
       let cache = perform (GetCache ()) in
       begin match VDMap.find_opt def cache with
-      | Some b -> b
-      | None ->
-        let cache' = ref (VDMap.add def true cache) in
-        let b =
-          match VDescr.is_empty def with
-          | b -> b
-          | effect GetCache (), k -> continue k !cache'
-          | effect SetCache c, k -> cache' := c ; continue k ()
-        in
-        let cache = if b then !cache' else VDMap.add def false cache in
-        perform (SetCache cache); b
+        | Some b -> b
+        | None ->
+          let cache' = ref (VDMap.add def true cache) in
+          let b =
+            match VDescr.is_empty def with
+            | b -> b
+            | effect GetCache (), k -> continue k !cache'
+            | effect SetCache c, k -> cache' := c ; continue k ()
+          in
+          let cache = if b then !cache' else VDMap.add def false cache in
+          perform (SetCache cache); b
       end
   let leq t1 t2 = diff t1 t2 |> is_empty
   let equiv t1 t2 = leq t1 t2 && leq t2 t1
@@ -121,16 +137,16 @@ module rec Node : Node with type vdescr = VDescr.t and type descr = VDescr.Descr
     let direct_nodes t = def t |> VDescr.direct_nodes |> NSet.of_list in
     let rec aux ts =
       let ts' = ts
-      |> NSet.to_list
-      |> List.map direct_nodes
-      |> List.fold_left NSet.union ts
+                |> NSet.to_list
+                |> List.map direct_nodes
+                |> List.fold_left NSet.union ts
       in
       if NSet.equal ts ts' then ts' else aux ts'
     in
     aux (NSet.singleton t)
 
   let dependencies t =
-    match t.dependencies with 
+    match t.dependencies with
     | Some d -> d
     | None -> let d = dependencies t in t.dependencies <- Some d; d
 
@@ -140,11 +156,11 @@ module rec Node : Node with type vdescr = VDescr.t and type descr = VDescr.Descr
 
   let of_eqs eqs =
     let deps = eqs
-              |> List.fold_left (fun acc (_, t) -> NSet.union (dependencies t) acc) NSet.empty in
+               |> List.fold_left (fun acc (_, t) -> NSet.union (dependencies t) acc) NSet.empty in
     let copies = NSet.fold (fun n acc -> NMap.add n (mk ()) acc) deps NMap.empty in
     let new_node n =
       match eqs |> List.find_opt (fun (v,_) ->
-        VDescr.equal (VDescr.mk_var v) (def n)) with
+          VDescr.equal (VDescr.mk_var v) (def n)) with
       | None -> NMap.find n copies
       | Some (_,n) -> NMap.find n copies (* Optimisation to avoid introducing a useless node *)
     in
@@ -153,18 +169,18 @@ module rec Node : Node with type vdescr = VDescr.t and type descr = VDescr.Descr
         let deps_ok n =
           let vs = vars_toplevel n in
           eqs |> List.for_all (fun (v,n) ->
-            VarSet.mem v vs |> not || new_node n |> has_def
-          )
+              VarSet.mem v vs |> not || new_node n |> has_def
+            )
         in
-        match NSet.elements deps |> List.find_opt deps_ok with
+        match deps |> find_opt_of_iter deps_ok NSet.iter with
         | None -> raise (Invalid_argument "Set of equations is not contractive.")
         | Some n ->
           let nn = new_node n in
           if has_def nn |> not then begin
             let s = eqs |> List.filter_map (fun (v,n) ->
-              let nn = new_node n in
-              if has_def nn then Some (v, def nn) else None
-            ) |> VarMap.of_list in
+                let nn = new_node n in
+                if has_def nn then Some (v, def nn) else None
+              ) |> VarMap.of_list in
             let d = def n |> VDescr.map_nodes new_node |> VDescr.substitute s in
             define nn d
           end ;
@@ -178,18 +194,18 @@ module rec Node : Node with type vdescr = VDescr.t and type descr = VDescr.Descr
     let s = s |> VarMap.map (fun n -> def n) in
     (* Optimisation: reuse nodes if possible *)
     let unchanged n = VarSet.disjoint (vars n) dom in
-    let deps = dependencies t |> NSet.to_list
-      |> List.filter (fun n -> unchanged n |> not) in
-    let copies = List.fold_left (fun acc n -> NMap.add n (mk ()) acc) NMap.empty deps in
+    let deps = dependencies t
+               |> NSet.filter  (fun n -> unchanged n |> not) in
+    let copies = NSet.fold (fun n acc -> NMap.add n (mk ()) acc) deps NMap.empty in
     let new_node n =
       match NMap.find_opt n copies with
       | Some n -> n
       | None -> n
     in
-    deps |> List.iter (fun n ->
-      let d = def n |> VDescr.map_nodes new_node |> VDescr.substitute s in
-      define (new_node n) d
-    ) ;
+    deps |> NSet.iter (fun n ->
+        let d = def n |> VDescr.map_nodes new_node |> VDescr.substitute s in
+        define (new_node n) d
+      ) ;
     new_node t
 
   let factorize t =
@@ -198,15 +214,17 @@ module rec Node : Node with type vdescr = VDescr.t and type descr = VDescr.Descr
       match NMap.find_opt t !cache with
       | Some n -> n
       | None ->
-        begin match NMap.bindings !cache
-          |> List.find_opt (fun (t',_) -> equiv t t') with
-        | Some (_, n) -> n
-        | None ->
-          let n = mk () in
-          cache := NMap.add t n (!cache) ;
-          let vd = def t |> VDescr.map_nodes aux in
-          define n vd ;
-          n
+        begin match
+            !cache
+            |> find_opt_of_iter2 (fun t' _ -> equiv t t') NMap.iter
+          with
+          | Some (_, n) -> n
+          | None ->
+            let n = mk () in
+            cache := NMap.add t n (!cache) ;
+            let vd = def t |> VDescr.map_nodes aux in
+            define n vd ;
+            n
         end
     in
     aux t

--- a/src/core/utils/dnf.ml
+++ b/src/core/utils/dnf.ml
@@ -60,14 +60,14 @@ module Make'(A:Atom)(A':Atom' with type t=A.t and type leaf=A.leaf)(N:Node) = st
       | (a, b)::c ->
         let a' = A'.to_t' (a, b) in
         let c' = aux c in
-        carthesian_product a' c' |> List.filter_map (fun (a, a') -> A'.combine a a')
+        cartesian_product a' c' |> List.filter_map (fun (a, a') -> A'.combine a a')
     in
     let dnf = dnf |> List.map (fun (cp, cn, l) ->
       let cp = cp |> List.map (fun a -> (a, true)) in
       let cn = cn |> List.map (fun a -> (a, false)) in
       cp@cn, l
     ) in
-    dnf |> List.map (fun (c,l) -> aux c |> List.map (fun c -> (c,l))) |> List.concat
+    dnf |> List.concat_map (fun (c,l) -> aux c |> List.map (fun c -> (c,l)))
   let from_dnf any dnf = combine any dnf
 
   let conv (a',l) = let ps,ns = A'.to_t a' in (ps,ns,l)

--- a/src/core/vdescr.ml
+++ b/src/core/vdescr.ml
@@ -32,7 +32,7 @@ module Make(N:Node) = struct
     Bdd.leaves t |> List.for_all Descr.is_empty
 
   let direct_nodes t =
-    Bdd.leaves t |> List.map Descr.direct_nodes |> List.concat
+    Bdd.leaves t |> List.concat_map Descr.direct_nodes
 
   let map f t =
     Bdd.map_leaves f t

--- a/src/main/repl.ml
+++ b/src/main/repl.ml
@@ -42,11 +42,11 @@ let rec compute_expr env e =
         let arrow = Ty.get_descr ty1 |> Descr.get_arrows in
         Op.Arrows.apply arrow ty2
       in
-      RTy (carthesian_product tys1 tys2 |> List.map apply)
+      RTy (cartesian_product tys1 tys2 |> List.map apply)
     | RSubst s1, RSubst s2 ->
-      RSubst (carthesian_product s1 s2 |> List.map (fun (s1, s2) -> Subst.compose s2 s1))
+      RSubst (cartesian_product s1 s2 |> List.map (fun (s1, s2) -> Subst.compose s2 s1))
     | RTy ty, RSubst s ->
-      RTy (carthesian_product ty s |> List.map (fun (ty, s) -> Subst.apply s ty))
+      RTy (cartesian_product ty s |> List.map (fun (ty, s) -> Subst.apply s ty))
     | _, _ -> failwith "Invalid application."
     in
     r, env
@@ -64,7 +64,7 @@ let rec compute_expr env e =
       | GEQ -> poly_leq env ty2 ty1
       | EQ -> poly_leq env ty1 ty2 && poly_leq env ty2 ty1
     in
-    RBool (carthesian_product tys1 tys2 |> List.map aux), env
+    RBool (cartesian_product tys1 tys2 |> List.map aux), env
 
 let params pparams env =
   let aliases =

--- a/src/types/tallying.ml
+++ b/src/types/tallying.ml
@@ -13,106 +13,125 @@ module Make(VO:VarOrder) = struct
     let compare = VO.compare
   end
   module VarSet = Set.Make(Var)
+  module VarMap = Map.Make(Var)
 
-  type norm_constr = Left of Var.t * Ty.t | Right of Ty.t * Var.t
-  type merged_constr = Ty.t * Var.t * Ty.t
+  module Constr = struct
+    type t = Ty.t * Var.t * Ty.t (* s ≤ α ≤ t *)
 
-  module type Constr = sig
-    type t
-    val leq : t -> t -> bool
-    val compare : t -> t -> int
-    val pp : Format.formatter -> t -> unit
-  end
-
-  module NormConstr = struct
-    type t = norm_constr
-    let leq t1 t2 =
-      match t1, t2 with
-      | Left (v1,t1), Left (v2,t2) when Var.equal v1 v2 -> Ty.leq t1 t2
-      | Right (t1,v1), Right (t2,v2) when Var.equal v1 v2 -> Ty.leq t2 t1
-      | _, _ -> false
-    let compare c1 c2 =
-      let var = function Left (v,_) -> v | Right (_,v) -> v in
-      let ty = function Left (_,ty) -> ty | Right (ty,_) -> ty in
-      let cmp_constructor c1 c2 =
-        match c1, c2 with
-        | Left _, Left _ | Right _, Right _ -> 0
-        | Left _, Right _ -> -1
-        | Right _, Left _ -> 1
-      in
-      Var.compare (var c1) (var c2) |> ccmp
-      cmp_constructor c1 c2 |> ccmp
-      Ty.compare (ty c1) (ty c2)
-    let pp fmt t =
-      match t with
-      | Left (v,ty) -> Format.fprintf fmt "%a <= %a" Var.pp v Printer.print_ty' ty
-      | Right (ty,v) -> Format.fprintf fmt "%a <= %a" Printer.print_ty' ty Var.pp v
-  end
-
-  module MergedConstr = struct
-    type t = merged_constr
-    let leq (t1,v1,t1') (t2,v2,t2') =
+    (* C1 subsumes C2 they are on the same variable
+       and gives better bounds (larger lower bound and smaller upper bound)
+    *)
+    let subsumes (t1, v1, t1') (t2, v2, t2') =
       Var.equal v1 v2 &&
-        Ty.leq t2 t1 && Ty.leq t1' t2'
+      Ty.leq t2 t1 && Ty.leq t1' t2'
+
     let compare (t1,v1,t1') (t2,v2,t2')=
       Var.compare v1 v2 |> ccmp
-      Ty.compare t1 t2 |> ccmp
-      Ty.compare t1' t2'
-    let pp fmt (ty,v,ty') =
-      Format.fprintf fmt "%a <= %a <= %a"
-        Printer.print_ty' ty Var.pp v Printer.print_ty' ty'
+        Ty.compare t1 t2 |> ccmp
+        Ty.compare t1' t2'
   end
 
-  module ConstrSet(C:Constr) = struct
-    module CS = Set.Make(C)
-    type t = CS.t
-    let any : t = CS.empty
-    let singleton = CS.singleton
-    let normalize t =
-      let cs = CS.to_list t in
-      let cs = cs |> filter_among_others (fun c cs ->
-        cs |> List.exists (fun c' -> C.leq c' c) |> not
-        ) in
-      CS.of_list cs
-    let to_list = CS.to_list
-    let of_list lst = CS.of_list lst |> normalize
-    let add e t = CS.add e t |> normalize
-    let cap t1 t2 = CS.union t1 t2 |> normalize
-    let leq t1 t2 = t2 |> CS.for_all (fun cs2 ->
-      t1 |> CS.exists (fun cs1 -> C.leq cs1 cs2)
-      )
-    let compare = CS.compare
-    (* let pp fmt t = Format.fprintf fmt "%a" (print_seq C.pp " ; ") (CS.to_list t) *)
+  (* As in CDuce, we follow POPL'15 but keep constraint merged:
+     - A Constraint Set C, is a (sorted list of triples) (s, α, t)
+     - Adding a new constraint for an existing variable merges them.
+  *)
+  module ConstrSet = struct
+    type t = [] | (::) of Constr.t * t
+    let any = []
+    let singleton e = [e]
+    let merge ((s, v, t) as c) ((s', _, t') as c') =
+      (* Don't create a new constraint if an existing one is
+         already better. This is only needed to have the
+         same resolution order of constraint solving and
+         check with the baseline. TODO: remove. *)
+      if Constr.subsumes c c' then c else
+      if Constr.subsumes c' c then c' else
+        (Ty.cup s s', v, Ty.cap t t')
+
+    let rec add ((_, v, _) as c) l =
+      match l with
+        [] -> [ c ]
+      | ((_, v', _) as c') :: ll ->
+        let n = Var.compare v v' in
+        if n < 0 then c::l
+        else if n = 0 then (merge c c')::ll
+        else c' :: add c ll
+
+    let rec cap l1 l2 =
+      match l1, l2 with
+      | [],  _ -> l2
+      | _, []  -> l1
+      | ((_,v1, _) as c1)::ll1, ((_, v2, _) as c2)::ll2 ->
+        let n = Var.compare v1 v2 in
+        if n < 0 then c1 :: cap ll1 l2
+        else if n > 0 then c2 :: cap l1 ll2
+        else (merge c1 c2)::cap ll1 ll2
+
+    (* A constraint set l1 subsumes a constraint set l2 if
+       forall constraint c2 in m2, there exists
+       c1 in t1 such that c1 subsumes c2
+    *)
+    let rec subsumes l1 l2 =
+      match l1, l2 with
+      | _, [] -> true
+      | [], _ -> false
+      | ((_,v1, _) as c1)::ll1, ((_, v2, _) as c2)::ll2 ->
+        let n = Var.compare v1 v2 in
+        if n < 0 then subsumes ll1 l2
+        else if n > 0 then false
+        else Constr.subsumes c1 c2 && subsumes ll1 ll2
+
+    let rec compare l1 l2 =
+      match l1, l2 with
+        [], [] -> 0
+      | [], _ -> -1
+      | _, [] -> 1
+      | c1 :: ll1, c2 :: ll2 ->
+        Constr.compare c1 c2 |> ccmp
+          compare ll1 ll2
+
+    let rec to_list_map f = function
+        [] -> List.[]
+      | e :: ll -> (f e)::to_list_map f ll
   end
 
-  module ConstrSets(C:Constr) = struct
-    module CS = ConstrSet(C)
-    module CSS = Set.Make(CS)
-    type t = CSS.t
-    let empty : t = CSS.empty
-    let any : t = CSS.singleton CS.any
-    let singleton = CSS.singleton
-    let normalize t =
-      let css = CSS.to_list t in
-      let css = css |> filter_among_others (fun cs css ->
-        css |> List.exists (fun cs' -> CS.leq cs cs') |> not
-        ) in
-      CSS.of_list css
-    let cup t1 t2 = CSS.union t1 t2 |> normalize
+  module ConstrSets = struct
+    module CS = ConstrSet
+    (* Constraint sets are ordered list of non subsumable elements.
+       They represent union of constraints, so we maintain the invariant
+       that we don't want to add a constraint set that subsumes an already
+       existing one.
+    *)
+    type t = CS.t list
+    let empty : t = []
+    let any : t = [CS.any]
+    let singleton e = [e]
+    let single e = singleton (CS.singleton e)
+    let rec insert_aux c l =
+      match l with
+        [] -> [c]
+      | c' :: ll ->
+        if CS.subsumes c c' then raise Exit
+        else
+          let n = CS.compare c c' in
+          if n < 0 then (if List.exists (CS.subsumes c) ll then raise Exit else c::l)
+          else if n = 0 then l
+          else c' :: insert_aux c ll
+
+    let add c l = try insert_aux c l with Exit -> l
+
+    let cup t1 t2 = List.fold_left (fun acc cs -> add cs acc) t1 t2
     let cap t1 t2 =
-      let t1, t2 = CSS.elements t1, CSS.elements t2 in
-      cartesian_product t1 t2 |> List.map (fun (cs1,cs2) -> CS.cap cs1 cs2)
-      |> CSS.of_list |> normalize
-    let disj t = List.fold_left cup empty t |> normalize
-    let conj t = List.fold_left cap any t |> normalize
-    let to_list = CSS.to_list
-    (* let pp fmt t =
-      Format.fprintf fmt "%a" (print_seq_cut CS.pp) (CSS.to_list t) *)
+      (cartesian_product t1 t2)
+      |> List.fold_left (fun acc (cs1,cs2) -> add (CS.cap cs1 cs2) acc) empty
+
+    let disj t = List.fold_left cup empty t
+    let conj t = List.fold_left cap any t
+    let to_list l = l
+
   end
 
-  module NCSS = ConstrSets(NormConstr)
-  module NCS = NCSS.CS
-  module MCSS = ConstrSets(MergedConstr)
+  module MCSS = ConstrSets
   module MCS = MCSS.CS
 
   module Summand = struct
@@ -121,20 +140,29 @@ module Make(VO:VarOrder) = struct
     let of_line (pvs, nvs, d) : t =
       (VarSet.of_list pvs, VarSet.of_list nvs, d)
 
+
     let to_ty (pvs, nvs, d) =
       [(pvs |> VarSet.to_list, nvs |> VarSet.to_list, d)] |> VDescr.of_dnf |> Ty.of_def
 
-    let vars (pvs, nvs, _) = VarSet.union pvs nvs
+    let pos_var v (pvs, nvs, d) =
+      let t = (VarSet.remove v pvs, nvs, d) |> to_ty in
+      (Ty.empty, v, Ty.neg t)
 
-    let single v (pvs, nvs, d) =
-      if VarSet.mem v pvs then
-        let t = (VarSet.remove v pvs, nvs, d) |> to_ty in
-        Left (v, Ty.neg t) |> NCS.singleton
-      else if VarSet.mem v nvs then
-        let t = (pvs, VarSet.remove v nvs, d) |> to_ty in
-        Right (t, v) |> NCS.singleton
-      else
-        assert false
+    let neg_var v (pvs, nvs, d) =
+      let t = (pvs, VarSet.remove v nvs, d) |> to_ty in
+      (t, v, Ty.any)
+
+    let smallest_toplevel delta ((pvs, nvs, _) as s) =
+      match VarSet.(
+          min_elt_opt (diff pvs delta),
+          min_elt_opt (diff nvs delta))
+      with
+      | None, None -> None
+      | Some v, None -> Some (pos_var v s)
+      | None, Some v -> Some (neg_var v s)
+      | Some v1, Some v2 ->
+        if Var.compare v1 v2 <= 0 then Some (pos_var v1 s)
+        else Some (neg_var v2 s)
   end
 
   module VDSet = Set.Make(VDescr)
@@ -144,22 +172,22 @@ module Make(VO:VarOrder) = struct
       if Base.VarSet.subset (Ty.vars t) delta_ty then
         (* Optimisation: performing tallying on an expression with
            no polymorphic type variable should be as fast as subtyping. *)
-        begin if Ty.is_empty t then NCSS.any else NCSS.empty end
+        begin if Ty.is_empty t then MCSS.any else MCSS.empty end
       else
         let vd = Ty.def t in
-        if VDSet.mem vd m then NCSS.any
+        if VDSet.mem vd m then MCSS.any
         else
           let m = VDSet.add vd m in
           let summands = vd |> VDescr.dnf |> VDescr.Dnf.simplify |> List.map Summand.of_line in
-          summands |> List.map (aux_summand m) |> NCSS.conj
+          summands |> List.map (aux_summand m) |> MCSS.conj
     and aux_summand m summand =
-      match VarSet.diff (Summand.vars summand) delta |> VarSet.elements with
-      | [] ->
+      match Summand.smallest_toplevel delta summand with
+      | None ->
         let (_,_,d) = summand in
         aux_descr m d
-      | v::_ -> Summand.single v summand |> NCSS.singleton
-    and aux_descr m d =
-      Descr.components d |> List.map (aux_comp m) |> NCSS.conj
+      | Some cs -> MCSS.single cs
+    and aux_descr m d  =
+      Descr.components d |> List.map (aux_comp m) |> MCSS.conj
     and aux_comp m c =
       let open Descr in
       match c with
@@ -171,128 +199,109 @@ module Make(VO:VarOrder) = struct
       | Records c -> aux_records m c
     and aux_atoms _ d =
       match Atoms.destruct d with
-      | true, [] -> NCSS.any
-      | _, _ -> NCSS.empty
+      | true, [] -> MCSS.any
+      | _, _ -> MCSS.empty
     and aux_intervals _ d =
       match Intervals.destruct d with
-      | [] -> NCSS.any
-      | _ -> NCSS.empty
+      | [] -> MCSS.any
+      | _ -> MCSS.empty
     and aux_tags m tag =
       let (cs, others) = tag |> Tags.components in
-      if others then NCSS.empty
+      if others then MCSS.empty
       else cs |>
-        List.map (fun c -> TagComp.as_atom c |> snd |> aux m)
-        |> NCSS.conj
+           List.map (fun c -> TagComp.as_atom c |> snd |> aux m)
+           |> MCSS.conj
     and aux_arrows m arr =
       arr |> Arrows.dnf |> Arrows.Dnf.simplify
-      |> List.map (aux_arrow m) |> NCSS.conj
+      |> List.map (aux_arrow m) |> MCSS.conj
     and aux_tuples m tup =
       let (comps, others) = tup |> Tuples.components in
-      if others then NCSS.empty
-      else comps |> List.map (aux_tuplecomp m) |> NCSS.conj
+      if others then MCSS.empty
+      else comps |> List.map (aux_tuplecomp m) |> MCSS.conj
     and aux_tuplecomp m tup =
       let n = TupleComp.len tup in
       tup |> TupleComp.dnf |> TupleComp.Dnf.simplify
-      |> List.map (aux_tuple m n) |> NCSS.conj
+      |> List.map (aux_tuple m n) |> MCSS.conj
     and aux_records m r =
       r |> Records.dnf |> Records.Dnf.simplify
-      |> List.map (aux_record m) |> NCSS.conj
+      |> List.map (aux_record m) |> MCSS.conj
     and aux_arrow m (ps, ns, _) =
       let pt, _ = List.split ps in
       let dom = Ty.disj pt in
       let aux_n (nt,nt') =
         let css1 = Ty.cap nt (Ty.neg dom) |> aux m in
         let aux_p (p1, p2) =
-          if p2 = [] then NCSS.any else
+          if p2 = [] then MCSS.any else
             let pt1, _ = List.split p1 in
             let dom1 = Ty.disj pt1 in
             let _, pt2' = List.split p2 in
             let codom2 = Ty.conj pt2' in
             let css1 = Ty.cap nt (Ty.neg dom1) |> aux m in
             let css2 = Ty.cap codom2 (Ty.neg nt') |> aux m in
-            NCSS.cup css1 css2
+            MCSS.cup css1 css2
         in
-        let css2 = subsets ps |> List.map aux_p |> NCSS.conj in
-        NCSS.cap css1 css2
+        let css2 = subsets ps |> List.map aux_p |> MCSS.conj in
+        MCSS.cap css1 css2
       in
-      ns |> List.map aux_n |> NCSS.disj
+      ns |> List.map aux_n |> MCSS.disj
     and aux_tuple m n (ps, ns, _) =
       let ps = mapn (fun () -> List.init n (fun _ -> Ty.any)) Ty.conj ps in
       let aux_n nss =
         let csss = nss |> List.mapi (fun i ns ->
-          let pcomp = List.nth ps i in
-          let ncomp = ns |> List.map (fun ns -> List.nth ns i) |> Ty.disj |> Ty.neg in
-          Ty.cap pcomp ncomp |> aux m
-        ) in
-        NCSS.disj csss
+            let pcomp = List.nth ps i in
+            let ncomp = ns |> List.map (fun ns -> List.nth ns i) |> Ty.disj |> Ty.neg in
+            Ty.cap pcomp ncomp |> aux m
+          ) in
+        MCSS.disj csss
       in
-      ns |> partitions n |> List.map aux_n |> NCSS.conj
+      ns |> partitions n |> List.map aux_n |> MCSS.conj
     and aux_record m (ps, ns, _) =
       let open Records in
       let open Atom in
       let dom = List.fold_left
-        (fun acc a -> LabelSet.union acc (dom a))
-        LabelSet.empty (ps@ns) |> LabelSet.to_list in
+          (fun acc a -> LabelSet.union acc (dom a))
+          LabelSet.empty (ps@ns) |> LabelSet.to_list in
       let ps, ns =
         ps |> List.map (to_tuple_with_default dom),
         ns |> List.map (to_tuple_with_default dom) in
       let n = List.length dom + 1 in
-    (* We reuse the same algorithm as for tuples *)
+      (* We reuse the same algorithm as for tuples *)
       let ps = mapn (fun () -> List.init n (fun _ -> Ty.O.any)) Ty.O.conj ps in
       let aux_n nss =
         let csss = nss |> List.mapi (fun i ns ->
-          let pcomp = List.nth ps i in
-          let ncomp = ns |> List.map (fun ns -> List.nth ns i) |> Ty.O.disj |> Ty.O.neg in
-          Ty.O.cap pcomp ncomp |> aux_oty m
-        ) in
-        NCSS.disj csss
+            let pcomp = List.nth ps i in
+            let ncomp = ns |> List.map (fun ns -> List.nth ns i) |> Ty.O.disj |> Ty.O.neg in
+            Ty.O.cap pcomp ncomp |> aux_oty m
+          ) in
+        MCSS.disj csss
       in
-      ns |> partitions n |> List.map aux_n |> NCSS.conj
+      ns |> partitions n |> List.map aux_n |> MCSS.conj
     and aux_oty m (n,o) =
-      if o then NCSS.empty else aux m n
+      if o then MCSS.empty else aux m n
     in
     aux (VDSet.empty) t
 
   (* TODO: Normalize using psi, in the same way as for subtyping *)
 
   let merge delta_ty delta cs =
-    let rec merge m cs =
-      cs |> NCS.to_list |> step1 |> step2 m []
-    and step1 cs =
+    (* Step1 from the paper is useless, since the ConstrSet maintains
+       merged constraints
+    *)
+    let rec step2 m prev (cs : MCS.t) =
       match cs with
-      | [] -> []
-      | (Left (v,t))::(Left (v',t'))::cs when Var.equal v v' ->
-        (Left (v, Ty.cap t t'))::cs |> step1
-      | (Right (t,v))::(Right (t',v'))::cs when Var.equal v v' ->
-        (Right (Ty.cup t t', v))::cs |> step1
-      | hd::tl -> hd::(step1 tl)
-    and step2 m prev cs =
-      match cs with
-      | [] -> NCS.of_list prev |> NCSS.singleton
-      | (Left (v,t))::(Right (t',v'))::cs when Var.equal v v' ->
+      | ConstrSet.[] -> prev |> MCSS.singleton
+      | ((t',_, t) as constr) :: cs' ->
         let ty = Ty.diff t' t in
         if VDSet.mem (Ty.def ty) m then
-          step2 m ((Right (t',v'))::(Left (v,t))::prev) cs
+          step2 m (MCS.add constr prev) cs'
         else
           let m = VDSet.add (Ty.def ty) m in
           let css = norm delta_ty delta ty in
-          let css' = (Left (v,t))::(Right (t',v'))::cs@prev |> NCS.of_list |> NCSS.singleton in
-          let css = NCSS.cap css css' in
-          css |> NCSS.to_list |> List.map (merge m) |> NCSS.disj
-      | hd::cs -> step2 m (hd::prev) cs
+          let css' = cs |> MCS.cap prev |> MCSS.singleton in
+          let css = MCSS.cap css css' in
+          css |> MCSS.to_list |> List.map (step2 m MCS.any) |> MCSS.disj
     in
-    let regroup cs =
-      let rec aux cs =
-        match cs with
-        | [] -> MCS.any
-        | (Left (v,t))::(Right (t',v'))::cs when Var.equal v v' ->
-            MCS.add (t', v, t) (aux cs)
-        | (Left (v,t))::cs -> MCS.add (Ty.empty, v, t) (aux cs)
-        | (Right (t,v))::cs -> MCS.add (t, v, Ty.any) (aux cs)
-      in
-      NCS.to_list cs |> aux |> MCSS.singleton
-    in
-    merge (VDSet.empty) cs |> NCSS.to_list |> List.map regroup |> MCSS.disj
+    step2 (VDSet.empty) MCS.any cs
 
   let solve cs =
     let renaming = ref Subst.identity in
@@ -311,15 +320,15 @@ module Make(VO:VarOrder) = struct
         let res = unify eqs' in
         Subst.add v (Subst.apply res ty') res
     in
-    cs |> MCS.to_list |> List.map to_eq |> unify |> Subst.map (Subst.apply !renaming)
+    cs |> MCS.to_list_map to_eq |> unify |> Subst.map (Subst.apply !renaming)
 
   let tally delta cs =
     let delta_ty = Base.VarSet.of_list delta in
     let delta = VarSet.of_list delta in
     let ncss = cs
-      |> List.map (fun (s,t) -> norm delta_ty delta (Ty.diff s t)) |> NCSS.conj in
+               |> List.map (fun (s,t) -> norm delta_ty delta (Ty.diff s t)) |> MCSS.conj in
     let mcss = ncss
-      |> NCSS.to_list |> List.map (merge delta_ty delta) |> MCSS.disj in
+               |> MCSS.to_list |> List.map (merge delta_ty delta) |> MCSS.disj in
     mcss |> MCSS.to_list |> List.map solve
 end
 
@@ -333,8 +342,8 @@ let tally_with_order cmp delta =
 let tally_with_priority preserve =
   let cnt = ref 0 in
   let pmap = List.fold_left
-    (fun acc v -> cnt := !cnt + 1 ; VarMap.add v !cnt acc)
-    VarMap.empty preserve
+      (fun acc v -> cnt := !cnt + 1 ; VarMap.add v !cnt acc)
+      VarMap.empty preserve
   in
   let cmp v1 v2 =
     match VarMap.find_opt v1 pmap, VarMap.find_opt v2 pmap with

--- a/src/types/tallying.ml
+++ b/src/types/tallying.ml
@@ -39,14 +39,7 @@ module Make(VO:VarOrder) = struct
     type t = [] | (::) of Constr.t * t
     let any = []
     let singleton e = [e]
-    let merge ((s, v, t) as c) ((s', _, t') as c') =
-      (* Don't create a new constraint if an existing one is
-         already better. This is only needed to have the
-         same resolution order of constraint solving and
-         check with the baseline. TODO: remove. *)
-      if Constr.subsumes c c' then c else
-      if Constr.subsumes c' c then c' else
-        (Ty.cup s s', v, Ty.cap t t')
+    let merge (s, v, t) (s', _, t') = (Ty.cup s s', v, Ty.cap t t')
 
     let rec add ((_, v, _) as c) l =
       match l with

--- a/src/utils/sstt_utils.ml
+++ b/src/utils/sstt_utils.ml
@@ -166,3 +166,13 @@ let (--) i j =
   let rec aux n acc =
     if n < i then acc else aux (n-1) (n :: acc)
   in aux j []
+
+let find_opt_of_iter (type a) (f : a -> bool) it col =
+  let exception Found of a in
+  try it (fun e -> if f e then raise_notrace (Found e)) col; None with
+  | Found e -> Some e
+
+let find_opt_of_iter2 (type a b) (f : a -> b -> bool) it col =
+  let exception Found of (a*b) in
+  try it (fun x y -> if f x y then raise_notrace (Found (x,y))) col; None with
+  | Found e -> Some e

--- a/src/utils/sstt_utils.ml
+++ b/src/utils/sstt_utils.ml
@@ -79,7 +79,7 @@ let subsets lst =
   aux [] [] lst
 
 let map_among_others' f lst =
-  let[@tail_mod_cons] rec aux left right =
+  let rec aux left right =
     match right with
       [] -> []
     | c :: right -> (f (List.rev left) c right)::(aux (c::left) right)


### PR DESCRIPTION
This PR implements various local optimizations int `core` and in the `tallying` module. These optimizations are non invasive. They are only local to some expressions or some function definitions,
they don't introduce caching or global state etc… They mainly consists of preventing the allocation of intermediary lists that are immediately traversed. In passing, the code of the tallying is cleaned-up and simplified, re-using the same representation for constraint sets as in CDuce (sorted list of constraints).
All optimizations but the last give a cumulative 20% speed-up on `MLsem/src/main/prototype.exe`.

The last commit impacts the printing of two examples in `sstt` and two examples in `MLsem`. For `MLsem`, the diff indicates that everything is still correct, up-to reordering of types:
```
-swap: ∀'a,'b,'c,'d. ('b & int -> ('a & int -> array('c) -> ()) & ('a -> dict('d | 'b & int | 'a, 'c) -> ())) & ('b -> 'a -> dict('d | 'b | 'a, 'c) -> ()) 
+swap: ∀'a,'b,'c,'d. ('b -> 'a -> dict('d | 'b | 'a, 'c) -> ()) & ('b & int -> ('a -> dict('d | 'b & int | 'a, 'c) -> ()) & ('a & int -> array('c) -> ())) 

-implicit11: ((int, int) -> int) & ((any, ~int) | (~int, any) -> No) 
+implicit11: ((int, int) -> int) & (tuple2 \ (int, int) -> No) 
```
The two optimizations are:
 - a (useless) re-ordering of constraints during `tallying` (for `swap`) (that was added to maintain the printing order)
 - fast paths for `Node.{cap/cup/diff}`. If their arguments is trivially (physical equality) `any/empty` then the corresponding `any/empty/unchanged` result is returned. This make it faster but also prevent the creation of new `nodes` which in turns helps algorithms that memoize and create new types.

Both optimizations add an extra 25% speed-up, for a total of ~45% speed-up (tested on two machines).
