### PR TITLE
Add `any : t` and `empty : t` to the `Node` signature

### DIFF
--- a/src/lib/sstt/core/components/records.ml
+++ b/src/lib/sstt/core/components/records.ml
@@ -6,9 +6,9 @@ module OTy(N:Node) = struct
   type node = N.t
   type t = node * bool
 
-  let any () = (N.any (), true)
-  let empty () = (N.empty (), false)
-  let absent () = (N.empty (), true)
+  let any = (N.any, true)
+  let empty = (N.empty, false)
+  let absent = (N.empty, true)
   let required t = (t, false)
   let optional t = (t, true)
   let get (t,_) = t
@@ -58,14 +58,14 @@ module Atom(N:Node) = struct
   let find lbl t =
     match LabelMap.find_opt lbl t.bindings, t.opened with
     | Some on, _ -> on
-    | None, true -> OTy.any ()
-    | None, false -> OTy.absent ()
+    | None, true -> OTy.any
+    | None, false -> OTy.absent
   let to_tuple dom t = dom |> List.map (fun l -> find l t)
   let to_tuple_with_default dom t =
     if t.opened then
-      (OTy.any ())::(to_tuple dom t)
+      OTy.any::(to_tuple dom t)
     else
-      (OTy.absent ())::(to_tuple dom t)  
+      OTy.absent::(to_tuple dom t)  
   let simplify t =
     let not_any _ on = OTy.is_any on |> not in
     let not_absent _ on = OTy.is_absent on |> not in
@@ -92,8 +92,8 @@ module Atom'(N:Node) = struct
   let find lbl t =
     match LabelMap.find_opt lbl t.bindings with
     | Some on -> on
-    | None when t.opened -> OTy.any ()
-    | None -> OTy.absent ()
+    | None when t.opened -> OTy.any
+    | None -> OTy.absent
   let simplify t =
     let bindings =
       let not_any _ on = OTy.is_any on |> not in
@@ -154,10 +154,10 @@ module Make(N:Node) = struct
   let diff = Bdd.diff
 
   let conj n ps =
-    let init = fun () -> List.init n (fun _ -> ON.any ()) in
+    let init = fun () -> List.init n (fun _ -> ON.any) in
     mapn init ON.conj ps
   let disj n ps =
-    let init = fun () -> List.init n (fun _ -> ON.empty ()) in
+    let init = fun () -> List.init n (fun _ -> ON.empty) in
     mapn init ON.disj ps
 
   let forall_distribute_diff f ss tt =
@@ -212,7 +212,7 @@ module Make(N:Node) = struct
         | None -> []
         | Some lbls ->
           let bindings =
-            lbls |> LabelSet.elements |> List.map (fun l -> (l,ON.any ()))
+            lbls |> LabelSet.elements |> List.map (fun l -> (l,ON.any))
             |> LabelMap.of_list
           in
           [{Atom.bindings=bindings ; Atom.opened=false}]

--- a/src/lib/sstt/core/components/tuples.ml
+++ b/src/lib/sstt/core/components/tuples.ml
@@ -41,10 +41,10 @@ module MakeC(N:Node) = struct
   let diff (tag1, t1) (tag2, t2) = check_tag tag1 tag2 ; tag1, Bdd.diff t1 t2
 
   let conj n ps =
-    let init = fun () -> List.init n (fun _ -> N.any ()) in
+    let init = fun () -> List.init n (fun _ -> N.any) in
     mapn init N.conj ps
   let disj n ps =
-    let init = fun () -> List.init n (fun _ -> N.empty ()) in
+    let init = fun () -> List.init n (fun _ -> N.empty) in
     mapn init N.disj ps
 
   let forall_distribute_diff f ss tt =
@@ -91,13 +91,13 @@ module MakeC(N:Node) = struct
 
     let to_t a = [a], []
     let to_t' (ns,b) =
-      let any_tuple n = List.init n (fun _ -> N.any()) in
+      let any_tuple n = List.init n (fun _ -> N.any) in
       let rec aux ns =
         match ns with
         | [] -> []
         | n::ns ->
           let this = (N.neg n)::(any_tuple (List.length ns)) in
-          let others = aux ns |> List.map (fun s -> (N.any())::s) in
+          let others = aux ns |> List.map (fun s -> N.any::s) in
           this::others
       in
       if b then [ns] else aux ns
@@ -110,7 +110,7 @@ module MakeC(N:Node) = struct
   module Dnf = Dnf.Make(DnfAtom)(N)
 
   let dnf (_,t) = Bdd.dnf t |> Dnf.mk
-  let dnf' (n,t) = dnf (n,t) |> Dnf'.from_dnf (List.init n (fun _ -> N.any ()))
+  let dnf' (n,t) = dnf (n,t) |> Dnf'.from_dnf (List.init n (fun _ -> N.any))
   let of_dnf tag dnf =
     dnf |> List.iter (fun (ps,ns,_) ->
         ps |> List.iter (fun a -> check_tag tag (Atom.tag a)) ;

--- a/src/lib/sstt/core/core.ml
+++ b/src/lib/sstt/core/core.ml
@@ -5,20 +5,18 @@ include Base
 
 module Ty : Ty = struct
   module N = Node.Node
-
   type t = N.t
 
   module VDescr = Node.VDescr
   module O = struct
     include Records.OTy(N)
-    let any, empty, absent = any (), empty (), absent ()
   end
-
   let simpl t = N.with_own_cache N.simplify t ; t
   let s f t = f t |> simpl
   let s' f t = simpl t |> f
 
-  let any, empty = N.any ()|> simpl, N.empty ()|> simpl
+  let any = N.any |> simpl
+  let empty =  N.empty |> simpl
   let def, of_def = s' N.def, s N.of_def
 
   let mk_var, mk_descr, get_descr = s N.mk_var, s N.mk_descr, s' N.get_descr

--- a/src/lib/sstt/core/core.ml
+++ b/src/lib/sstt/core/core.ml
@@ -11,7 +11,7 @@ module Ty : Ty = struct
   module O = struct
     include Records.OTy(N)
   end
-  let simpl t = N.with_own_cache N.simplify t ; t
+  let simpl t = N.with_own_cache N.simplify t
   let s f t = f t |> simpl
   let s' f t = simpl t |> f
 

--- a/src/lib/sstt/core/core.ml
+++ b/src/lib/sstt/core/core.ml
@@ -11,7 +11,7 @@ module Ty : Ty = struct
   module O = struct
     include Records.OTy(N)
   end
-  let simpl t = N.with_own_cache N.simplify t
+  let simpl t = N.with_own_cache N.simplify t ; t
   let s f t = f t |> simpl
   let s' f t = simpl t |> f
 

--- a/src/lib/sstt/core/node.ml
+++ b/src/lib/sstt/core/node.ml
@@ -211,8 +211,6 @@ include (struct
         | Some nt -> define ~simplified:true nt (VDescr.neg s_def)
       end
 
-    let simplify t = simplify t;t
-
     let dependencies t =
       let direct_nodes t = def t |> VDescr.direct_nodes |> NSet.of_list in
       let rec aux ts =

--- a/src/lib/sstt/core/node.ml
+++ b/src/lib/sstt/core/node.ml
@@ -211,6 +211,8 @@ include (struct
         | Some nt -> define ~simplified:true nt (VDescr.neg s_def)
       end
 
+    let simplify t = simplify t;t
+
     let dependencies t =
       let direct_nodes t = def t |> VDescr.direct_nodes |> NSet.of_list in
       let rec aux ts =

--- a/src/lib/sstt/core/node.ml
+++ b/src/lib/sstt/core/node.ml
@@ -5,239 +5,296 @@ open Sstt_utils
 open Base
 open Sigs
 
-module rec Node : Node with type vdescr = VDescr.t and type descr = VDescr.Descr.t = struct
+(* The Node module is where we close the knot:
+   - a Node.t contains a VDescr.t
+   - a VDescr.t contains a Descr.t
+   - a Descr.t contains several components, e.g. Arrows, Records, …
+   - the Atoms of Arrows, Record contain Node.t
 
-  module NSet = Set.Make(Node)
-  module NMap = Map.Make(Node)
-  module VDMap = Map.Make(VDescr)
-  type _ Effect.t += GetCache: unit -> (bool VDMap.t) t
-  type _ Effect.t += SetCache: bool VDMap.t -> unit t
+   Since these modules form a cycle, one of them must be safe.
+   The problem is that they all contains top-level values that are not
+   closures, namely `any` and `empty`. We therefore split the definition
+   so that any and empty exist in a module outside of the cycle.
+   An delayed initialization function is called to populate their content.
+   Lastly, the whole mess is hidden via a top-level include with
+   a contstrained signature (at the end of the file) to only expose the
+   Node and VDescr modules, with abstract types.
 
-  type vdescr = VDescr.t
-  type descr = VDescr.Descr.t
-  type t = {
-    id : int ;
-    mutable def : VDescr.t option ;
-    mutable simplified : bool ;
-    mutable dependencies : NSet.t option;
-    mutable neg : t option
+*)
 
-  }
 
-  let has_def t = Option.is_some t.def
-  let def t = t.def |> Option.get
+include (struct
+  module rec TyRef : sig 
+    (* The type of type reference, this module only contains the type definition to avoid
+       repeating it everywhere. *)
 
-  let hash t = Hashtbl.hash t.id
-  let compare t1 t2 = Int.compare t1.id t2.id
-  let equal t1 t2 = (t1.id = t2.id)
-
-  let next_id =
-    let c = ref 0 in
-    fun () -> c := !c + 1 ; !c
-
-  let mk () =
-    {
-      id = next_id () ;
-      def = None ;
-      simplified = false ;
-      dependencies = None;
-      neg = None;
-
+    type t = {
+      id : int ;
+      mutable def : VDescr.t option ;
+      mutable simplified : bool ;
+      mutable dependencies : NSet.t option;
+      mutable neg : t option
     }
+  end = TyRef (* Trick: a recursive module with only types can be its own definition *)
 
-  let define ?(simplified=false) t d =
-    t.def <- Some d ;
-    t.dependencies <- None ;
-    t.simplified <- simplified
-  let cons ?(simplified=false) d =
-    let t = mk () in
-    define ~simplified t d ; t
+  and AnyEmpty : sig
+    (* The definition of any and empty, TyRef.t creation and the delayed init function *)
+    type t = TyRef.t
+    val mk : unit -> t
+    val any : t
+    val empty : t
+    val init : VDescr.t -> VDescr.t -> unit
+  end = struct
+    type t = TyRef.t
+    let next_id =
+      let c = ref ~-1 in
+      fun () -> incr c; !c
+    open TyRef
+    let mk () =
+      {
+        id = next_id () ;
+        def = None ;
+        simplified = false ;
+        dependencies = None;
+        neg = None;
+      }
 
-  let of_def d = d |> cons
+    let empty = mk ()
+    let any = mk ()
+    let init empty_def any_def =
+      assert (empty.def = None && any.def = None);
+      empty.def <- Some empty_def;
+      empty.neg <- Some any;
+      empty.simplified <- true;
+      empty.dependencies <- Some (NSet.singleton empty);
 
-  let any, empty =
-    let empty = VDescr.empty |> cons ~simplified:true in
-    let any = VDescr.any |> cons ~simplified:true in
-    empty.neg <- Some any;
-    any.neg <- Some empty;
-    (fun () -> any), (fun () -> empty)
+      any.def <- Some any_def;
+      any.neg <- Some empty;
+      any.simplified <- true;
+      any.dependencies <- Some (NSet.singleton any)
+  end
+  and Node : Node with type t = AnyEmpty.t and type vdescr = VDescr.t and type descr = VDescr.Descr.t = struct
+    (* The module which contains any and empty that is passed to Vdescr.Make *)
+    include PreNode
+    let any = AnyEmpty.any
+    let empty = AnyEmpty.empty  
+  end
+  and NSet : Set.S with type elt = AnyEmpty.t = Set.Make(PreNode) (* Sets of Node.t, but use PreNode to have a well defined cycle *)
+  and VDescr : VDescr' with type node = Node.t = Vdescr.Make(Node) (* Instanciate VDescr *)
+  and PreNode : PreNode with type t = AnyEmpty.t and type vdescr = VDescr.t and type descr = VDescr.Descr.t = struct
+    (* The PreNode module that contain the entry points of all functions on types. *)
+    module NMap = Map.Make(PreNode)
+    module VDMap = Map.Make(VDescr)
+    type _ Effect.t += GetCache: (bool VDMap.t) t
+    type _ Effect.t += SetCache: bool VDMap.t -> unit t
 
-  let is_any_ =
-    let any = any () in
-    fun t -> t == any
-  let is_empty_ =
-    let empty = empty () in
-    fun t -> t == empty
-  let cap t1 t2 =
-    if is_empty_ t1 || is_empty_ t2 then empty ()
-    else if is_any_ t1 then t2
-    else if is_any_ t2 then t1
-    else
-      VDescr.cap (def t1) (def t2) |> cons
-  let cup t1 t2 =
-    if is_any_ t1 || is_any_ t2 then any ()
-    else if is_empty_ t1 then t2
-    else if is_empty_ t2 then t1
-    else
-      VDescr.cup (def t1) (def t2) |> cons
-  let neg t =
-    match t.neg with
-    | Some s -> s
-    | None ->
-      let s = t |> def |> VDescr.neg
-        |> cons ~simplified:t.simplified in
-      t.neg <- Some s;
-      s.neg <- Some t;
-      s
+    type vdescr = VDescr.t
+    type descr = VDescr.Descr.t
 
-  let diff t1 t2 =
-    if is_empty_ t1 || is_any_ t2 then empty ()
-    else if is_any_ t1 then neg t2
-    else if is_empty_ t2 then t1
-    else
-      VDescr.diff (def t1) (def t2) |> cons
-  let conj ts = List.fold_left cap (any ()) ts
-  let disj ts = List.fold_left cup (empty ()) ts
+    type t = TyRef.t
+    open TyRef
+    open AnyEmpty
 
-  let is_empty t =
-    let def = def t in
-    if t.simplified then
-      VDescr.equal def VDescr.empty
-    else
-      let cache = perform (GetCache ()) in
-      begin match VDMap.find_opt def cache with
-        | Some b -> b
-        | None ->
-          let cache' = ref (VDMap.add def true cache) in
-          let b =
-            match VDescr.is_empty def with
-            | b -> b
-            | effect GetCache (), k -> continue k !cache'
-            | effect SetCache c, k -> cache' := c ; continue k ()
-          in
-          let cache = if b then !cache' else VDMap.add def false cache in
-          perform (SetCache cache); b
-      end
-  let leq t1 t2 = diff t1 t2 |> is_empty
-  let equiv t1 t2 = leq t1 t2 && leq t2 t1
-  let is_any t = neg t |> is_empty
-  let disjoint t1 t2 = cap t1 t2 |> is_empty
-  let with_own_cache f t =
-    let cache = ref VDMap.empty in
-    match f t with
-    | x -> x
-    | effect GetCache (), k -> continue k !cache
-    | effect SetCache c, k -> cache := c ; continue k ()
 
-  let rec simplify t =
-    if not t.simplified then begin
-      let s_def = def t |> VDescr.simplify in
-      define ~simplified:true t s_def ;
-      s_def |> VDescr.direct_nodes |> List.iter simplify ;
+    let () = init VDescr.empty VDescr.any (* Delayed initialization *)
+
+    let has_def t = Option.is_some t.def
+    let def t = t.def |> Option.get
+
+    let hash t = Hashtbl.hash t.id
+    let compare t1 t2 = Int.compare t1.id t2.id
+    let equal t1 t2 = (t1.id = t2.id)
+
+
+    let define ?(simplified=false) t d =
+      t.def <- Some d ;
+      t.dependencies <- None ;
+      t.simplified <- simplified
+    let cons ?(simplified=false) d =
+      let t = mk () in
+      define ~simplified t d ; t
+
+    let of_def d = d |> cons
+
+    let cap t1 t2 =
+      if t1 == empty || t2 == empty then empty
+      else if t1 == any then t2
+      else if t2 == any then t1
+      else
+        VDescr.cap (def t1) (def t2) |> cons
+
+    let cup t1 t2 =
+      if t1 == any || t2 == any then any
+      else if t1 == empty then t2
+      else if t2 == empty then t1
+      else
+        VDescr.cup (def t1) (def t2) |> cons
+    let neg t =
       match t.neg with
-      | None -> ()
-      | Some nt -> define ~simplified:true nt (VDescr.neg s_def)
-    end
-
-  let dependencies t =
-    let direct_nodes t = def t |> VDescr.direct_nodes |> NSet.of_list in
-    let rec aux ts =
-      let ts' = ts
-                |> NSet.to_list
-                |> List.map direct_nodes
-                |> List.fold_left NSet.union ts
-      in
-      if NSet.equal ts ts' then ts' else aux ts'
-    in
-    aux (NSet.singleton t)
-
-  let dependencies t =
-    match t.dependencies with
-    | Some d -> d
-    | None -> let d = dependencies t in t.dependencies <- Some d; d
-
-  let vars_toplevel t = def t |> VDescr.direct_vars |> VarSet.of_list
-  let vars t =
-    NSet.fold (fun n -> VarSet.union (vars_toplevel n)) (dependencies t) VarSet.empty
-
-  let of_eqs eqs =
-    let deps = eqs
-               |> List.fold_left (fun acc (_, t) -> NSet.union (dependencies t) acc) NSet.empty in
-    let copies = NSet.fold (fun n acc -> NMap.add n (mk ()) acc) deps NMap.empty in
-    let new_node n =
-      match eqs |> List.find_opt (fun (v,_) ->
-          VDescr.equal (VDescr.mk_var v) (def n)) with
-      | None -> NMap.find n copies
-      | Some (_,n) -> NMap.find n copies (* Optimisation to avoid introducing a useless node *)
-    in
-    let rec define_all deps =
-      if NSet.is_empty deps |> not then
-        let deps_ok n =
-          let vs = vars_toplevel n in
-          eqs |> List.for_all (fun (v,n) ->
-              VarSet.mem v vs |> not || new_node n |> has_def
-            )
-        in
-        match deps |> find_opt_of_iter deps_ok NSet.iter with
-        | None -> raise (Invalid_argument "Set of equations is not contractive.")
-        | Some n ->
-          let nn = new_node n in
-          if has_def nn |> not then begin
-            let s = eqs |> List.filter_map (fun (v,n) ->
-                let nn = new_node n in
-                if has_def nn then Some (v, def nn) else None
-              ) |> VarMap.of_list in
-            let d = def n |> VDescr.map_nodes new_node |> VDescr.substitute s in
-            define nn d
-          end ;
-          define_all (NSet.remove n deps)
-    in
-    define_all deps ;
-    eqs |> List.map (fun (v,n) -> v,new_node n)
-
-  let substitute s t =
-    let dom = VarMap.fold (fun n _ -> VarSet.add n) s VarSet.empty in
-    let s = s |> VarMap.map (fun n -> def n) in
-    (* Optimisation: reuse nodes if possible *)
-    let unchanged n = VarSet.disjoint (vars n) dom in
-    let deps = dependencies t
-               |> NSet.filter  (fun n -> unchanged n |> not) in
-    let copies = NSet.fold (fun n acc -> NMap.add n (mk ()) acc) deps NMap.empty in
-    let new_node n =
-      match NMap.find_opt n copies with
-      | Some n -> n
-      | None -> n
-    in
-    deps |> NSet.iter (fun n ->
-        let d = def n |> VDescr.map_nodes new_node |> VDescr.substitute s in
-        define (new_node n) d
-      ) ;
-    new_node t
-
-  let factorize t =
-    let cache = ref NMap.empty in
-    let rec aux t =
-      match NMap.find_opt t !cache with
-      | Some n -> n
+      | Some s -> s
       | None ->
-        begin match
-            !cache
-            |> find_opt_of_iter2 (fun t' _ -> equiv t t') NMap.iter
-          with
-          | Some (_, n) -> n
-          | None ->
-            let n = mk () in
-            cache := NMap.add t n (!cache) ;
-            let vd = def t |> VDescr.map_nodes aux in
-            define n vd ;
-            n
-        end
-    in
-    aux t
+        let s = t |> def |> VDescr.neg
+                |> cons ~simplified:t.simplified in
+        t.neg <- Some s;
+        s.neg <- Some t;
+        s
 
-  let mk_var v = VDescr.mk_var v |> cons
-  let mk_descr d = VDescr.mk_descr d |> cons
-  let get_descr t = def t |> VDescr.get_descr
-  let nodes t = dependencies t |> NSet.to_list
-end
-and VDescr : VDescr' with type node = Node.t = Vdescr.Make(Node)
+    let diff t1 t2 =
+      if t1 == empty || t2 == any then empty
+      else if t1 == any then neg t2
+      else if t2 == empty then t1
+      else
+        VDescr.diff (def t1) (def t2) |> cons
+
+    let conj ts = List.fold_left cap any ts
+    let disj ts = List.fold_left cup empty ts
+
+    let is_empty t =
+      let def = def t in
+      if t.simplified then
+        VDescr.equal def VDescr.empty
+      else
+        let cache = perform GetCache in
+        begin match VDMap.find_opt def cache with
+          | Some b -> b
+          | None ->
+            let cache' = ref (VDMap.add def true cache) in
+            let b =
+              match VDescr.is_empty def with
+              | b -> b
+              | effect GetCache , k -> continue k !cache'
+              | effect SetCache c, k -> cache' := c ; continue k ()
+            in
+            let cache = if b then !cache' else VDMap.add def false cache in
+            perform (SetCache cache); b
+        end
+
+    let leq t1 t2 = diff t1 t2 |> is_empty
+    let equiv t1 t2 = leq t1 t2 && leq t2 t1
+    let is_any t = neg t |> is_empty
+    let disjoint t1 t2 = cap t1 t2 |> is_empty
+
+    let with_own_cache f t =
+      let cache = ref VDMap.empty in
+      match f t with
+      | x -> x
+      | effect GetCache, k -> continue k !cache
+      | effect SetCache c, k -> cache := c ; continue k ()
+
+    let rec simplify t =
+      if not t.simplified then begin
+        let s_def = def t |> VDescr.simplify in
+        define ~simplified:true t s_def ;
+        s_def |> VDescr.direct_nodes |> List.iter simplify ;
+        match t.neg with
+        | None -> ()
+        | Some nt -> define ~simplified:true nt (VDescr.neg s_def)
+      end
+
+    let dependencies t =
+      let direct_nodes t = def t |> VDescr.direct_nodes |> NSet.of_list in
+      let rec aux ts =
+        let ts' = ts
+                  |> NSet.to_list
+                  |> List.map direct_nodes
+                  |> List.fold_left NSet.union ts
+        in
+        if NSet.equal ts ts' then ts' else aux ts'
+      in
+      aux (NSet.singleton t)
+
+    let dependencies t =
+      match t.dependencies with
+      | Some d -> d
+      | None -> let d = dependencies t in t.dependencies <- Some d; d
+
+    let vars_toplevel t = def t |> VDescr.direct_vars |> VarSet.of_list
+    let vars t =
+      NSet.fold (fun n -> VarSet.union (vars_toplevel n)) (dependencies t) VarSet.empty
+
+    let of_eqs eqs =
+      let deps = eqs
+                 |> List.fold_left (fun acc (_, t) -> NSet.union (dependencies t) acc) NSet.empty in
+      let copies = NSet.fold (fun n acc -> NMap.add n (mk ()) acc) deps NMap.empty in
+      let new_node n =
+        match eqs |> List.find_opt (fun (v,_) ->
+            VDescr.equal (VDescr.mk_var v) (def n)) with
+        | None -> NMap.find n copies
+        | Some (_,n) -> NMap.find n copies (* Optimisation to avoid introducing a useless node *)
+      in
+      let rec define_all deps =
+        if NSet.is_empty deps |> not then
+          let deps_ok n =
+            let vs = vars_toplevel n in
+            eqs |> List.for_all (fun (v,n) ->
+                VarSet.mem v vs |> not || new_node n |> has_def
+              )
+          in
+          match deps |> find_opt_of_iter deps_ok NSet.iter with
+          | None -> raise (Invalid_argument "Set of equations is not contractive.")
+          | Some n ->
+            let nn = new_node n in
+            if has_def nn |> not then begin
+              let s = eqs |> List.filter_map (fun (v,n) ->
+                  let nn = new_node n in
+                  if has_def nn then Some (v, def nn) else None
+                ) |> VarMap.of_list in
+              let d = def n |> VDescr.map_nodes new_node |> VDescr.substitute s in
+              define nn d
+            end ;
+            define_all (NSet.remove n deps)
+      in
+      define_all deps ;
+      eqs |> List.map (fun (v,n) -> v,new_node n)
+
+    let substitute s t =
+      let dom = VarMap.fold (fun n _ -> VarSet.add n) s VarSet.empty in
+      let s = s |> VarMap.map (fun n -> def n) in
+      (* Optimisation: reuse nodes if possible *)
+      let unchanged n = VarSet.disjoint (vars n) dom in
+      let deps = dependencies t
+                 |> NSet.filter  (fun n -> unchanged n |> not) in
+      let copies = NSet.fold (fun n acc -> NMap.add n (mk ()) acc) deps NMap.empty in
+      let new_node n =
+        match NMap.find_opt n copies with
+        | Some n -> n
+        | None -> n
+      in
+      deps |> NSet.iter (fun n ->
+          let d = def n |> VDescr.map_nodes new_node |> VDescr.substitute s in
+          define (new_node n) d
+        ) ;
+      new_node t
+
+    let factorize t =
+      let cache = ref NMap.empty in
+      let rec aux t =
+        match NMap.find_opt t !cache with
+        | Some n -> n
+        | None ->
+          begin match
+              !cache
+              |> find_opt_of_iter2 (fun t' _ -> equiv t t') NMap.iter
+            with
+            | Some (_, n) -> n
+            | None ->
+              let n = mk () in
+              cache := NMap.add t n (!cache) ;
+              let vd = def t |> VDescr.map_nodes aux in
+              define n vd ;
+              n
+          end
+      in
+      aux t
+
+    let mk_var v = VDescr.mk_var v |> cons
+    let mk_descr d = VDescr.mk_descr d |> cons
+    let get_descr t = def t |> VDescr.get_descr
+    let nodes t = dependencies t |> NSet.to_list
+  end
+
+
+end : sig
+           module rec Node : (Node with type vdescr = VDescr.t and type descr = VDescr.Descr.t)
+           and VDescr : VDescr with type node = Node.t
+         end)

--- a/src/lib/sstt/core/sigs.ml
+++ b/src/lib/sstt/core/sigs.ml
@@ -478,13 +478,12 @@ module type VDescr' = sig
   val substitute : t VarMap.t -> t -> t
 end
 
-module type Node = sig
+module type PreNode = sig
   type t
   type vdescr
   type descr
 
-  include TyBaseRef with type t := t and type node := t
-
+  include Comparable with type t:=t
   val def : t -> vdescr
   val of_def : vdescr -> t
 
@@ -506,7 +505,11 @@ module type Node = sig
 
   val hash : t -> int
 end
-
+module type Node = sig
+  include PreNode
+  val any : t
+  val empty : t
+end
 (* Ty *)
 
 module type Ty = sig

--- a/src/lib/sstt/core/sigs.ml
+++ b/src/lib/sstt/core/sigs.ml
@@ -501,7 +501,7 @@ module type PreNode = sig
   val of_eqs : (Var.t * t) list -> (Var.t * t) list
   val substitute : t VarMap.t -> t -> t
   val factorize : t -> t
-  val simplify : t -> t
+  val simplify : t -> unit
 
   val hash : t -> int
 end

--- a/src/lib/sstt/core/sigs.ml
+++ b/src/lib/sstt/core/sigs.ml
@@ -501,7 +501,7 @@ module type PreNode = sig
   val of_eqs : (Var.t * t) list -> (Var.t * t) list
   val substitute : t VarMap.t -> t -> t
   val factorize : t -> t
-  val simplify : t -> unit
+  val simplify : t -> t
 
   val hash : t -> int
 end


### PR DESCRIPTION
Split the definition of `Node` in several parts so that the `Node` module that is passed as argument to the `Vdescr.Make` functor contains `any` and `empty` as types rather than functions.

The split allows a safe `PreNode` module to exists on the cycle of mutually recursive modules, which allows the initialization of the modules to proceed without error.

