### PR TITLE
Full documentation and refactoring of sigs.ml

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,5 +1,6 @@
 (lang dune 3.17)
 (using menhir 3.0)
+(using mdx 0.4)
 
 (name sstt)
 
@@ -26,7 +27,7 @@
 (package
  (name sstt)
  (synopsis "Simple Set-Theoretic Types library")
- (depends (ocaml (>= 5.3.0)) dune zarith)
+ (depends (ocaml (>= 5.3.0)) (mdx :with-test) dune zarith)
 )
 
 (package

--- a/src/doc/sstt/dune
+++ b/src/doc/sstt/dune
@@ -1,0 +1,6 @@
+(documentation
+ (package sstt))
+
+(mdx
+ (package sstt)
+ (libraries sstt zarith))

--- a/src/doc/sstt/index.mld
+++ b/src/doc/sstt/index.mld
@@ -1,0 +1,136 @@
+{0 sstt index}
+
+{1 The {{!module-Sstt}sstt} library }
+
+The Simple Set-Theoretic Types library implements set-theoretic
+types and all related operations (set-theoretic operations, subtyping,
+type-substitution, tallying). The entry point of this library is the module 
+{!module-Sstt}.
+
+
+{1 Examples}
+
+{2 Building types}
+
+To build types, one needs to first build descriptors:
+{@ocaml[
+# open Sstt
+# #install_printer Printer.print_ty' ;;
+
+# let int = Descr.mk_intervals Intervals.any |> Ty.mk_descr ;;
+val int : Ty.t = int
+# let true_ = Descr.mk_enum (Enums.Atom.mk "true") |> Ty.mk_descr ;;
+val true_ : Ty.t = true
+# let false_ = Descr.mk_enum (Enums.Atom.mk "false") |> Ty.mk_descr ;;
+val false_ : Ty.t = false
+# let bool = Ty.cup true_ false_ ;;
+val bool : Ty.t = true | false
+# let int_x_bool = Descr.mk_tuple [ int; bool ] |> Ty.mk_descr ;;
+val int_x_bool : Ty.t = int, true | false
+]}
+Polymorphic types are just types built around variables. For instance, to build the type {m \alpha \rightarrow \beta}:
+{@ocaml[
+
+# let alpha = Ty.mk_var (Var.mk "'a") ;;
+val alpha : Ty.t = 'a
+# let beta = Ty.mk_var (Var.mk "'b") ;;
+val beta : Ty.t = 'b
+
+# let fun_a_b = Descr.mk_arrow (alpha, beta) |> Ty.mk_descr ;;
+val fun_a_b : Ty.t = 'a -> 'b
+]}
+
+Recursive types are built using systems of equations:
+
+{@ocaml[
+# #install_printer Var.pp ;;
+
+# let vx = Var.mk "'x" ;;
+val vx : VarSet.elt = 'x
+# let tx = Ty.mk_var vx ;;
+val tx : Ty.t = 'x
+# let vy = Var.mk "'y" ;;
+val vy : VarSet.elt = 'y
+# let ty = Ty.mk_var vy ;;
+val ty : Ty.t = 'y
+# let nil = Descr.mk_enum (Enums.Atom.mk "nil") |> Ty.mk_descr ;;
+val nil : Ty.t = nil
+# let int = Descr.mk_intervals Intervals.any |> Ty.mk_descr ;;
+val int : Ty.t = int
+# let int_x_ty = Descr.mk_tuple [ int; ty ] |> Ty.mk_descr ;;
+val int_x_ty : Ty.t = int, 'y
+# let bool_x_tx = Descr.mk_tuple [ bool; tx ] |> Ty.mk_descr ;;
+val bool_x_tx : Ty.t = true | false, 'x
+# let bool_x_tx_nil = Ty.cup nil bool_x_tx ;;
+val bool_x_tx_nil : Ty.t = nil | (true | false, 'x)
+]}
+We can now build and solve the system of equations:
+{math 
+\begin{array}{ccl}
+    X & = & (\texttt{int}\times Y)\\
+    Y & = & (\texttt{bool}\times X) \cup \texttt{nil}
+\end{array}
+}
+{@ocaml[
+# let solved = Ty.of_eqs [ (vx, int_x_ty);  (vy, bool_x_tx_nil) ] ;;
+val solved : (VarSet.elt * Ty.t) list =
+  [('x, x1 where x1 = int, nil | (true | false, x1));
+   ('y, x1 where x1 = nil | (true | false, (int, x1)))]
+
+# let int_bool_list = solved |> VarMap.of_list |> VarMap.find vx ;;
+val int_bool_list : Ty.t = x1 where x1 = int, nil | (true | false, x1)
+]}
+The type [int_bool_list] is now the recursive type encoding non empty lists (as nested pairs)
+of even length with integers at even positions and booleans at odd positions.
+
+{2 High level operations}
+
+{3 Subtyping and tallying}
+
+The subtyping test is [Ty.leq]. Continuing or example with lists:
+{@ocaml[
+# let mk_list ty =
+    let v = Var.mk "" in (* a fresh variable *)
+    let tv = Ty.mk_var v in
+    let ty_x_v = Descr.mk_tuple [ty; tv] |> Ty.mk_descr in
+    let ty_x_v_nil = Ty.cup nil ty_x_v in
+    [v, ty_x_v_nil ]
+    |> Ty.of_eqs |> List.hd |> snd ;;
+val mk_list : Ty.t -> Ty.t = <fun>
+
+# let any_list = mk_list Ty.any ;;
+val any_list : Ty.t = x1 where x1 = nil | (any, x1)
+]}
+We can now test for subtyping:
+{@ocaml[
+# Ty.leq int_bool_list any_list ;;
+- : bool = true
+]}
+
+As for tallying, one first needs to build a tallying instance (a set of constraint to be solved together):
+{@ocaml[
+# #install_printer Printer.print_subst' ;;
+# let alpha_list = mk_list Ty.(mk_var (Var.mk "'a")) ;;
+val alpha_list : Ty.t = x1 where x1 = nil | ('a, x1)
+
+# let int_list = mk_list int ;;
+val int_list : Ty.t = x1 where x1 = nil | (int, x1)
+
+# let t42_list = mk_list (Intervals.Atom.mk_singl (Z.of_int 42) |> Descr.mk_interval |> Ty.mk_descr)
+val t42_list : Ty.t = x1 where x1 = nil | (42, x1)
+
+# let constrs = [ (t42_list, alpha_list); (alpha_list, int_list) ] ;;
+val constrs : (Ty.t * Ty.t) list =
+  [(x1 where x1 = nil | (42, x1), x1 where x1 = nil | ('a, x1));
+   (x1 where x1 = nil | ('a, x1), x1 where x1 = nil | (int, x1))]
+
+# Tallying.tally VarSet.empty constrs ;;
+- : Subst.t list = [[
+                      'a: 42 | 'a & int
+                    ]]
+]} 
+
+Here, we solve the set of problems asking that a list of {m \alpha} must be
+larger than a list of (singleton type) [42] and must be smaller than a list of
+integers. It yields the unique solution 
+{m \alpha\mapsto \texttt{42}\cup\alpha\cap\texttt{int}}.

--- a/src/lib/sstt/core/base.ml
+++ b/src/lib/sstt/core/base.ml
@@ -1,8 +1,24 @@
 
+(** @canonical Sstt.Label *)
 module Label = Id.NamedIdentifier()
-module LabelMap = Map.Make(Label)
-module LabelSet = Set.Make(Label)
+(** Labels used for field names in records. *)
 
+(** @canonical Sstt.LabelSet *)
+module LabelSet = Set.Make(Label)
+(** Sets of labels. *)
+
+(** @canonical Sstt.LabelMap *)
+module LabelMap = Map.Make(Label)
+(** Maps indexed by labels. *)
+
+(** @canonical Sstt.Var *)
 module Var = Id.NamedIdentifier()
+(** Type variables. *)
+
+(** @canonical Sstt.VarSet *)
 module VarSet = Set.Make(Var)
+(** Sets of type variables. *)
+
+(** @canonical Sstt.VarMap *)
 module VarMap = Map.Make(Var)
+(** Maps indexed by type variables. *)

--- a/src/lib/sstt/core/components/arrows.ml
+++ b/src/lib/sstt/core/components/arrows.ml
@@ -58,7 +58,7 @@ module Make(N:Node) = struct
     let undesirable_leaf = not
     let leq t1 t2 = leq (Bdd.of_dnf t1) (Bdd.of_dnf t2)
   end
-  module Dnf = Dnf.Make(DnfAtom)(N)
+  module Dnf = DNF.Make(DnfAtom)(N)
 
   let dnf t = Bdd.dnf t |> Dnf.mk
   let of_dnf dnf = Dnf.mk dnf |> Bdd.of_dnf

--- a/src/lib/sstt/core/components/records.ml
+++ b/src/lib/sstt/core/components/records.ml
@@ -47,7 +47,7 @@ module Atom(N:Node) = struct
   module OTy = OTy(N)
 
   type node = N.t
-  type nonrec oty = node oty
+  type nonrec oty = node * bool
   type t = { bindings : oty LabelMap.t ; opened : bool }
   let map_nodes f t =
     { t with bindings = LabelMap.map (OTy.map_nodes f) t.bindings }
@@ -86,7 +86,7 @@ module Atom'(N:Node) = struct
   module OTy = OTy(N)
 
   type node = N.t
-  type nonrec oty = node oty
+  type nonrec oty = node * bool
   type t = { bindings : oty LabelMap.t ; opened : bool ; required : LabelSet.t option }
   let dom t = LabelMap.bindings t.bindings |> List.map fst |> LabelSet.of_list
   let find lbl t =
@@ -248,8 +248,8 @@ module Make(N:Node) = struct
       let res = { bindings ; opened ; required } in
       if is_empty res then None else Some (simplify res)
   end
-  module Dnf' = Dnf.Make'(DnfAtom)(DnfAtom')(N)
-  module Dnf = Dnf.Make(DnfAtom)(N)
+  module Dnf' = DNF.Make'(DnfAtom)(DnfAtom')(N)
+  module Dnf = DNF.Make(DnfAtom)(N)
 
   let dnf t = Bdd.dnf t |> Dnf.mk
   let dnf' t = dnf t |> Dnf'.from_dnf

--- a/src/lib/sstt/core/components/tags.ml
+++ b/src/lib/sstt/core/components/tags.ml
@@ -23,6 +23,7 @@ module MakeC(N:Node) = struct
   module Atom = Atom(N)
   module Bdd = Bdd.Make(Atom)(Bdd.BoolLeaf)
   module Tag = Atom.Tag
+  module Index = Tag
 
   type t = Tag.t * Bdd.t
   type node = N.t
@@ -33,7 +34,8 @@ module MakeC(N:Node) = struct
   let mk a = Atom.tag a, Bdd.singleton a
 
   let tag (tag,_) = tag
-
+  let index = tag
+  
   let check_tag tag tag' =
     if Tag.equal tag tag' |> not then
       raise (Invalid_argument "Heterogeneous tags.")
@@ -63,7 +65,7 @@ module MakeC(N:Node) = struct
     let undesirable_leaf = not
     let leq t1 t2 = leq (Bdd.of_dnf t1) (Bdd.of_dnf t2)
   end
-  module Dnf = Dnf.Make(DnfAtom)(N)
+  module Dnf = DNF.Make(DnfAtom)(N)
 
   let dnf (_,t) = Bdd.dnf t |> Dnf.mk
   let of_dnf tag dnf =
@@ -87,9 +89,9 @@ module MakeC(N:Node) = struct
 end
 
 module Make(N:Node) = struct
-  module TagComp = MakeC(N)
-  include Tagged.Make(TagComp)
+  module Comp = MakeC(N)
+  include Indexed.Make(Comp)
 
   let mk_comp p = mk p
-  let mk a = mk (TagComp.mk a)
+  let mk a = mk (Comp.mk a)
 end

--- a/src/lib/sstt/core/core.ml
+++ b/src/lib/sstt/core/core.ml
@@ -1,10 +1,33 @@
 open Sigs
 
-module Base = Base
-include Base
+(**
+   {1 Types and their components}
+
+   The API to manipulate them follows a layered structure to account for the fact that types
+   are equi-recursive:
+
+   - a type {m t} (implemented by {!Ty.t}) is a reference to a descriptor with top-level variables, {m t = v}
+   - a full descriptor with top-level variables {m v} (implemented by type {!VDescr.t}) represents a disjunctive normal form
+     of positive and negative top-level variables and monomorphic descriptors:
+     {math
+     v = \bigcup_{i=i\ldots m} ~~\bigcap_{j=1\ldots p} \alpha_{ij} \cap \bigcap_{j=1\ldots n} \lnot\beta_{ij} ~~\cap~~ d_i
+     }
+   - a monomorphic descriptor {m d} (implemented by {!Descr.t} is a disjoint union of components. Components are {{!Intervals} intervals},
+     {{!Enums} enums}, {{!Tuples} tuples}, {{!Tags} tagged types}, {{!Arrows} arrows} and {{!Records} records}.
+   - Components {{!Intervals} intervals} and {{!Enums}enums} correspond to basic types
+   - Components such as {{!Tuples} tuples}, {{!Tags} tagged types}, {{!Arrows} arrows} and {{!Records} records} correspond to type
+     constructors and are union of intersections of atoms, the latter containing type references {!Ty.t}. For instance,
+     the component for {{!Arrows} arrows} represents:
+      {math
+      a = \bigcup_{i=1\ldots m} \bigcap_{j=1 \ldots p} t_{ij}^1 \rightarrow t_{ij}^2 \cap \bigcap_{j=1 \ldots n} \lnot(t_{ij}^1 \rightarrow t_{ij}^2) 
+      }
+*)
+
+(** {2 Types and descriptors }*)
 
 module Ty : Ty = struct
   module N = Node.Node
+
   type t = N.t
 
   module VDescr = Node.VDescr
@@ -41,13 +64,76 @@ module Ty : Ty = struct
 
   let compare, equal, hash = N.compare, N.equal, N.hash
 end
+
+(** @canonical Sstt.VDescr *)
 module VDescr = Ty.VDescr
+
+(** @canonical Sstt.Descr *)
 module Descr = VDescr.Descr
-module Arrows = Descr.Arrows
-module Enums = Descr.Enums
-module Tags = Descr.Tags
-module TagComp = Tags.TagComp
+
+
+(** {2 Components } 
+
+    Components are the building blocks of types. Each component represents a
+    union of intersections (a DNF) of a particular "type constructor" (basic
+    types such as integers or enums, tuples, arrows, …).
+
+    The following modules are convenience aliases to modules found in
+    {!Ty.VDescr.Descr}.
+*)
+
+(** {3 Basic components }
+    These components represent the two basic types, integers and enums.
+*)
+
+(** @canonical Sstt.Intervals *)
 module Intervals = Descr.Intervals
+
+(** @canonical Sstt.Enums *)
+module Enums = Descr.Enums
+
+(** {3 Constructor components } 
+
+    Type constructor components come in two flavors: simple constructors such as
+    arrows or records and families such as tuples or tagged type. The latter are
+    infinte sets of components, indexed by a value (the arity for tuples and the tag
+    for tagged types).
+
+*)
+
+(** @canonical Sstt.Arrows *)
+module Arrows = Descr.Arrows
+
+(** @canonical Sstt.Records *)
 module Records = Descr.Records
+
+(** @canonical Sstt.Tuples *)
 module Tuples = Descr.Tuples
-module TupleComp = Tuples.TupleComp
+
+(** @canonical Sstt.TupleComp *)
+module TupleComp = Tuples.Comp
+
+(** @canonical Sstt.Tags *)
+module Tags = Descr.Tags
+
+(** @canonical Sstt.TagComp *)
+module TagComp = Tags.Comp
+
+(** 
+   {1 Named identifiers} 
+
+*)
+
+(** Identifiers (type variables, record fields) all share a common interface.
+    The library provides
+    {{!Stdlib.Set.S}sets} and {{!Stdlib.Map.S}maps} whose elements and keys are identifiers.
+*)
+
+module type NamedIdentifier = Id.NamedIdentifier
+
+(** @inline *) 
+include Base
+
+(** @canonical Sstt.Tag *)
+module Tag = Tags.Comp.Atom.Tag
+(** Tags used for tagged type (an alias of {!TagComp.Atom.Tag}). *)

--- a/src/lib/sstt/core/descr.ml
+++ b/src/lib/sstt/core/descr.ml
@@ -2,28 +2,28 @@ open Sigs
 open Sstt_utils
 
 module Make(N:Node) = struct
-  module Arrows = Arrows.Make(N)
-  module Enums = Enums
   module Intervals = Intervals
+  module Enums = Enums
+  module Arrows = Arrows.Make(N)
   module Records = Records.Make(N)
-  module Tags = Tags.Make(N)
   module Tuples = Tuples.Make(N)
+  module Tags = Tags.Make(N)
 
   type component =
+    | Intervals of Intervals.t
     | Enums of Enums.t
     | Arrows of Arrows.t
-    | Intervals of Intervals.t
     | Records of Records.t
-    | Tags of Tags.t
     | Tuples of Tuples.t
+    | Tags of Tags.t
 
   type t = {
+    intervals : Intervals.t;
     enums : Enums.t ;
-    tags : Tags.t ;
-    tuples : Tuples.t ;
     arrows : Arrows.t ;
     records : Records.t ;
-    intervals : Intervals.t
+    tuples : Tuples.t ;
+    tags : Tags.t ;
   }
   type node = N.t
 

--- a/src/lib/sstt/core/utils/DNF.ml
+++ b/src/lib/sstt/core/utils/DNF.ml
@@ -1,10 +1,11 @@
+(* The file is named DNF to avoid confusing ocamldep/dune with Dnf in sigs.ml *)
 open Sigs
 open Sstt_utils
 
 module type Atom = sig
   type leaf
   type t
-  
+
   val undesirable_leaf : leaf -> bool
   val leq : (t list * t list * leaf) list -> (t list * t list * leaf) list -> bool
 end
@@ -13,7 +14,7 @@ module type Atom' = sig
   type leaf
   type t
   type t'
-  
+
   val to_t : t' -> t list * t list
   val to_t' : t * bool -> t' list
   val combine : t' -> t' -> t' option
@@ -29,19 +30,19 @@ module Make(A:Atom)(N:Node) = struct
   let simplify dnf =
     (* Remove useless clauses that may be generated from the BDD *)
     let dnf = dnf |> map_among_others (fun (cp, cn, l) c_others ->
-      let cp = cp |> filter_among_others (fun _ cp_others ->
-        A.leq ((cp_others, cn, l)::c_others) dnf |> not
-      ) in
-      let cn = cn |> filter_among_others (fun _ cn_others ->
-        A.leq ((cp, cn_others, l)::c_others) dnf |> not
-      ) in
-      (cp, cn, l)
-    )
+        let cp = cp |> filter_among_others (fun _ cp_others ->
+            A.leq ((cp_others, cn, l)::c_others) dnf |> not
+          ) in
+        let cn = cn |> filter_among_others (fun _ cn_others ->
+            A.leq ((cp, cn_others, l)::c_others) dnf |> not
+          ) in
+        (cp, cn, l)
+      )
     in
     (* Remove useless summands (must be done AFTER clauses simplification) *)
     dnf |> filter_among_others (fun c c_others ->
-      A.leq (c::c_others) c_others |> not
-    )
+        A.leq (c::c_others) c_others |> not
+      )
 
   let mk t = N.with_own_cache mk t
   let simplify t = N.with_own_cache simplify t
@@ -63,10 +64,10 @@ module Make'(A:Atom)(A':Atom' with type t=A.t and type leaf=A.leaf)(N:Node) = st
         cartesian_product a' c' |> List.filter_map (fun (a, a') -> A'.combine a a')
     in
     let dnf = dnf |> List.map (fun (cp, cn, l) ->
-      let cp = cp |> List.map (fun a -> (a, true)) in
-      let cn = cn |> List.map (fun a -> (a, false)) in
-      cp@cn, l
-    ) in
+        let cp = cp |> List.map (fun a -> (a, true)) in
+        let cn = cn |> List.map (fun a -> (a, false)) in
+        cp@cn, l
+      ) in
     dnf |> List.concat_map (fun (c,l) -> aux c |> List.map (fun c -> (c,l)))
   let from_dnf any dnf = combine any dnf
 
@@ -75,9 +76,9 @@ module Make'(A:Atom)(A':Atom' with type t=A.t and type leaf=A.leaf)(N:Node) = st
   let simplify t =
     (* Remove useless summands *)
     t |> filter_among_others (fun a a_others ->
-      leq (a::a_others) a_others |> not
-    )
-  
+        leq (a::a_others) a_others |> not
+      )
+
   let to_dnf dnf' = List.map conv dnf'
 
   let from_dnf any t = N.with_own_cache (from_dnf any) t

--- a/src/lib/sstt/core/utils/id.ml
+++ b/src/lib/sstt/core/utils/id.ml
@@ -1,5 +1,5 @@
-
-module type NamedIdentifier = sig
+module type NamedIdentifier =
+sig
   type t
 
   (** [mk name] makes a new identifier of name [name].
@@ -22,13 +22,14 @@ module type NamedIdentifier = sig
   val pp_unique : Format.formatter -> t -> unit
 end
 
-module NamedIdentifier() : NamedIdentifier = struct
+module NamedIdentifier () : NamedIdentifier = struct
   type t = int * string
-  let next_id =
-    let c = ref 0 in
-    fun () -> c := !c + 1 ; !c
 
-  let mk name = (next_id (), name)
+    let next_id =
+      let c = ref 0 in
+      fun () -> c := !c + 1 ; !c
+
+  let mk name =  (next_id (), name)
   let name (_, name) = name
   let hash (i,_) = Hashtbl.hash i
   let compare (i1,_) (i2,_) = Int.compare i1 i2

--- a/src/lib/sstt/core/vdescr.ml
+++ b/src/lib/sstt/core/vdescr.ml
@@ -58,7 +58,7 @@ module Make(N:Node) = struct
     let undesirable_leaf l = Descr.equal l Descr.empty
     let leq t1 t2 = leq (Bdd.of_dnf t1) (Bdd.of_dnf t2)
   end
-  module Dnf = Dnf.Make(DnfAtom)(N)
+  module Dnf = DNF.Make(DnfAtom)(N)
 
   let dnf t = Bdd.dnf t |> Dnf.mk
   let of_dnf dnf = Dnf.mk dnf |> Bdd.of_dnf

--- a/src/lib/sstt/dune
+++ b/src/lib/sstt/dune
@@ -4,3 +4,4 @@
  (libraries sstt_utils zarith))
 
 (include_subdirs unqualified)
+

--- a/src/lib/sstt/types/extensions/abstracts.mli
+++ b/src/lib/sstt/types/extensions/abstracts.mli
@@ -2,16 +2,16 @@ open Core
 
 type variance = Cov | Contrav | Inv
 
-val is_abstract : TagComp.Tag.t -> bool
-val params_of : TagComp.Tag.t -> variance list
-val mk : TagComp.Tag.t -> Ty.t list -> Ty.t
-val mk_any : TagComp.Tag.t -> Ty.t
-val destruct : TagComp.t -> (TagComp.Tag.t * (Ty.t list list * Ty.t list list) list) option
+val is_abstract : Tag.t -> bool
+val params_of : Tag.t -> variance list
+val mk : Tag.t -> Ty.t list -> Ty.t
+val mk_any : Tag.t -> Ty.t
+val destruct : TagComp.t -> (Tag.t * (Ty.t list list * Ty.t list list) list) option
 
 type params = Printer.descr list
 type t = (params list * params list) list
-type printer = TagComp.Tag.t -> int -> Prec.assoc -> Format.formatter -> t -> unit
+type printer = Tag.t -> int -> Prec.assoc -> Format.formatter -> t -> unit
 val print : printer
 
-val define : printer -> string -> variance list -> TagComp.Tag.t * Printer.params
-val define' : string -> variance list -> TagComp.Tag.t * Printer.params
+val define : printer -> string -> variance list -> Tag.t * Printer.params
+val define' : string -> variance list -> Tag.t * Printer.params

--- a/src/lib/sstt/types/extensions/bools.mli
+++ b/src/lib/sstt/types/extensions/bools.mli
@@ -1,6 +1,6 @@
 open Core
 
-val tag : TagComp.Tag.t
+val tag : Tag.t
 
 val btrue : Ty.t
 val bfalse : Ty.t

--- a/src/lib/sstt/types/extensions/chars.mli
+++ b/src/lib/sstt/types/extensions/chars.mli
@@ -1,6 +1,6 @@
 open Core
 
-val tag : TagComp.Tag.t
+val tag : Tag.t
 
 type interval = char * char
 

--- a/src/lib/sstt/types/extensions/floats.mli
+++ b/src/lib/sstt/types/extensions/floats.mli
@@ -1,6 +1,6 @@
 open Core
 
-val tag : TagComp.Tag.t
+val tag : Tag.t
 
 type k = Ninf | Neg | Nzero | Pzero | Pos | Pinf | Nan
 

--- a/src/lib/sstt/types/extensions/lists/lists.mli
+++ b/src/lib/sstt/types/extensions/lists/lists.mli
@@ -1,30 +1,67 @@
+(** The type of heterogenous lists.
+
+    Lists are encoded {i à la} Lisp with as either a constant (the empty list [nil])
+    or a pair of a value (the {i head}) and a list (the {i tail}).
+
+    Lists are printed using a regular expression types whenever possible.
+*)
+
 open Core
 
-val tag : TagComp.Tag.t
+val tag : Tag.t
+(** The tag used for list type.
+*)
 
 val cons : Ty.t -> Ty.t -> Ty.t
+(** [cons hd tl] returns the type of lists formed by the head [hd] and the tail [tl].
+    The function does not check whether [tl] is a list.
+*)
+
 val nil : Ty.t
+(** The empty list. *)
+
 val any : Ty.t
+(** The type of all lists. *)
+
 val any_non_empty : Ty.t
+(** The type of all non-empty lists. *)
+
 val destruct : Ty.t -> (Ty.t * Ty.t) list
+(** [destruct t] returns a list [[ (hd1, tl1); …; (hdn, tln) ]] such
+    that [t] is equivalent to
+    {math
+
+    \bigcup_{i=1\ldots n}\texttt{cons} ~~\texttt{hd}_i ~~\texttt{tl}_i
+    }
+*)
+
 val destruct' : Ty.t -> Ty.t * Ty.t
+(** [destruct' t] returns the approximation such
+    that [t] is equovalent to
+    {math
+
+    \bigcup_{i=1\ldots n} \texttt{hd}_i ~~~\times~~~ 
+    \bigcup_{i=1\ldots n} \texttt{tl}_i
+    }
+    where [destruct t] = [[ (hd1, tl1); …; (hdn, tln) ]]
+*)
 
 val basic_printer_params : Printer.params
 
 type 'a regexp =
-| Epsilon
-| Symbol of 'a
-| Concat of 'a regexp list
-| Union of 'a regexp list
-| Star of 'a regexp
-| Plus of 'a regexp
-| Option of 'a regexp
+  | Epsilon
+  | Symbol of 'a
+  | Concat of 'a regexp list
+  | Union of 'a regexp list
+  | Star of 'a regexp
+  | Plus of 'a regexp
+  | Option of 'a regexp
 
 type basic = Nil | Cons of Printer.descr * Printer.descr
 
 type t =
-| Regexp of Printer.descr regexp
-| Basic of basic list
+  | Regexp of Printer.descr regexp
+  | Basic of basic list
 
 type printer = int -> Prec.assoc -> Format.formatter -> t -> unit
 

--- a/src/lib/sstt/types/extensions/strings.mli
+++ b/src/lib/sstt/types/extensions/strings.mli
@@ -1,6 +1,6 @@
 open Core
 
-val tag : TagComp.Tag.t
+val tag : Tag.t
 val str : string -> Ty.t
 val any : Ty.t
 

--- a/src/lib/sstt/types/op.ml
+++ b/src/lib/sstt/types/op.ml
@@ -21,8 +21,8 @@ module Arrows = struct
             let aux (e,ps) = certain_outputs (e::current_set) ps in
             take_one ps |> List.map aux |> List.flatten
           end
-      in
-      certain_outputs [] ps |> Ty.conj
+        in
+        certain_outputs [] ps |> Ty.conj
     end |> Ty.disj
 
   let worra t out =
@@ -55,7 +55,10 @@ module TupleComp = struct
     mapn (fun _ -> raise EmptyAtom) Ty.disj (as_union t)
 
   let proj i t =
-    as_union t |> List.map (fun lst -> List.nth lst i) |> Ty.disj
+    as_union t |> List.map (fun lst -> 
+        match List.nth_opt lst i with
+          Some v -> v
+        | None -> invalid_arg "Op.TupleComp.proj") |> Ty.disj
 
   let merge a1 a2 = a1@a2
 end
@@ -68,8 +71,8 @@ module Records = struct
     let open Records.Atom in
     Records.dnf' t |> Records.Dnf'.simplify |> List.map fst |>
     List.map (fun t ->
-      { bindings=t.Records.Atom'.bindings ; opened=t.opened }
-    )
+        { bindings=t.Records.Atom'.bindings ; opened=t.opened }
+      )
 
   let of_union lst =
     Records.of_dnf (List.map (fun atom -> [atom],[],true) lst)
@@ -79,8 +82,8 @@ module Records = struct
     let union_a a1 a2 =
       let dom = LabelSet.union (dom a1) (dom a2) in
       let bindings = dom |> LabelSet.to_list |> List.map (fun lbl ->
-        (lbl, Ty.O.cup (find lbl a1) (find lbl a2))
-      ) |> LabelMap.of_list in
+          (lbl, Ty.O.cup (find lbl a1) (find lbl a2))
+        ) |> LabelMap.of_list in
       { bindings ; opened = a1.opened || a2.opened }
     in
     match as_union t with
@@ -94,10 +97,10 @@ module Records = struct
     let open Records.Atom in
     let dom = LabelSet.union (dom a1) (dom a2) in
     let bindings = dom |> LabelSet.to_list |> List.map (fun lbl ->
-      let oty1, oty2 = find lbl a1, find lbl a2 in
-      let oty = if snd oty2 then Ty.O.cup oty1 (fst oty2, false) else oty2 in
-      (lbl, oty)
-    ) |> LabelMap.of_list in
+        let oty1, oty2 = find lbl a1, find lbl a2 in
+        let oty = if snd oty2 then Ty.O.cup oty1 (fst oty2, false) else oty2 in
+        (lbl, oty)
+      ) |> LabelMap.of_list in
     { bindings ; opened = a1.opened && a2.opened } |> Records.mk
 
   let remove a lbl =

--- a/src/lib/sstt/types/op.mli
+++ b/src/lib/sstt/types/op.mli
@@ -1,70 +1,90 @@
+(** High-level operations on types. *)
+
 open Core
 
+
 exception EmptyAtom
+(** Exception raised by some operations on tuples and records. *)
 
 module Arrows : sig
-    type t = Arrows.t
+  (** Operations on arrow types. *)
 
-    (** [dom t] returns the domain of the arrow component [t]. *)
-    val dom : t -> Ty.t
+  type t = Arrows.t
 
-    (** [apply t arg] returns the type resulting from the application
-    of an argument of type [arg] to a function [t]. An argument not
-    in the domain will yield the resulting type [any]. *)
-    val apply : t -> Ty.t -> Ty.t
+  (** [dom t] returns the domain of the arrow component [t]. *)
+  val dom : t -> Ty.t
 
-    (** [worra t res] returns the type that must necessarily have an argument
-    applied to the function [t] for the result to have type [res]
-    (assuming the application did not diverge). *)
-    val worra : t -> Ty.t -> Ty.t
+  (** [apply t arg] returns the type resulting from the application
+      of an argument of type [arg] to a function [t]. An argument not
+      in the domain will yield the resulting type [any]. *)
+  val apply : t -> Ty.t -> Ty.t
+
+  (** [worra t res] returns the type that must necessarily have an argument
+      applied to the function [t] for the result to have type [res] (assuming
+      the application did not diverge). For instance, for an arrow type 
+      {m t\equiv (\texttt{int}\rightarrow\texttt{bool})\cap(\texttt{string}\rightarrow\texttt{int})},
+      {m \texttt{worra} t \texttt{bool}} returns {m \texttt{int}} ([worra] is
+      [arrow] in reverse).
+  *)
+  val worra : t -> Ty.t -> Ty.t
 end
 
 module TupleComp : sig
-    type t = TupleComp.t
-    type atom = TupleComp.Atom.t
+  (** Operations on tuple types. *)
 
-    (** [as_union t] expresses [t] as an union of non-empty atoms. *)
-    val as_union : t -> atom list
+  type t = TupleComp.t
+  type atom = TupleComp.Atom.t
 
-    (** [of_union n atoms] returns the [n]-uple component composed of the union [atoms]. *)
-    val of_union : int -> atom list -> t
+  (** [as_union t] expresses [t] as an union of non-empty atoms. *)
+  val as_union : t -> atom list
 
-    (** [approx t] over-approximates [t] as a non-empty atom.
-    Raises: [EmptyAtom] if [t] is empty. *)
-    val approx : t -> atom
+  (** [of_union n atoms] returns the [n]-uple component composed of the union [atoms]. *)
+  val of_union : int -> atom list -> t
 
-    (** [proj n t] returns the type resulting from the projection on the
-    [n]-th component (0-indexed) of [t]. *)
-    val proj : int -> t -> Ty.t
+  (** [approx t] over-approximates [t] as a non-empty atom.
+      {%html: <style>ul.at-tags > li > p { display: inline }</style>%}
+      @raise EmptyAtom if [t] is empty. *)
+  val approx : t -> atom
 
-    (** [merge t1 t2] returns the atom resulting from the concatenation of
-    [t1] and [t2]. *)
-    val merge : atom -> atom -> atom
+  (** [proj n t] returns the type resulting from the projection on the
+      [n]-th component (0-indexed) of [t]. 
+      {%html: <style>ul.at-tags > li > p { display: inline }</style>%}
+      @raise Invalid_argument if [n] is negative or greater than the arity of [t].
+  *)
+  val proj : int -> t -> Ty.t
+
+  (** [merge t1 t2] returns the atom resulting from the concatenation of
+      [t1] and [t2]. *)
+  val merge : atom -> atom -> atom
 end
 
 module Records : sig
-    type t = Records.t
-    type atom = Records.Atom.t
+  (** Operations on record types. *)
 
-    (** [as_union t] over-approximates [t] as an union of non-empty atoms. *)
-    val as_union : t -> atom list
+  type t = Records.t
+  type atom = Records.Atom.t
 
-    (** [of_union atoms] returns the record component composed of the union [atoms]. *)
-    val of_union : atom list -> t
+  (** [as_union t] over-approximates [t] as an union of non-empty atoms. *)
+  val as_union : t -> atom list
 
-    (** [approx t] over-approximates [t] as a non-empty atom.
-    Raises: [EmptyAtom] if [t] is empty. *)
-    val approx : t -> atom
+  (** [of_union atoms] returns the record component composed of the union [atoms]. *)
+  val of_union : atom list -> t
 
-    (** [proj l t] returns the (possibly absent) type resulting
-    from the projection on the label [l] of [t]. *)
-    val proj : Label.t -> t -> Ty.O.t
+  (** [approx t] over-approximates [t] as a non-empty atom.
+      {%html: <style>ul.at-tags > li > p { display: inline }</style>%}
+      @raise EmptyAtom if [t] is empty. *)
+  val approx : t -> atom
 
-    (** [merge t1 t2] returns the atom resulting from the merging of
-    [t1] and [t2] (non-absent fields in [t2] override those in [t1]). *)
-    val merge : atom -> atom -> t
+  (** [proj l t] returns the (possibly absent) type resulting
+      from the projection on the label [l] of [t]. 
+  *)
+  val proj : Label.t -> t -> Ty.O.t
 
-    (** [remove t l] returns the atom obtained by making the field [l]
-    absent in [t]. *)
-    val remove : atom -> Label.t -> t
+  (** [merge t1 t2] returns the atom resulting from the merging of
+      [t1] and [t2] (non-absent fields in [t2] override those in [t1]). *)
+  val merge : atom -> atom -> t
+
+  (** [remove t l] returns the atom obtained by making the field [l]
+      absent in [t]. *)
+  val remove : atom -> Label.t -> t
 end

--- a/src/lib/sstt/types/printer/prec.ml
+++ b/src/lib/sstt/types/printer/prec.ml
@@ -1,30 +1,55 @@
-type unop =
-| Neg
-type binop =
-| Diff | Arrow
-type varop =
-| Tuple | Cup | Cap
+(** Precedence of operators and associativity *)
 
+(** Unary operators *)
+type unop =
+  | Neg
+
+(** Binary operators *)
+type binop =
+  | Diff | Arrow
+
+(** Variadic operators *)
+type varop =
+  | Tuple | Cup | Cap
+
+(** Associativity *)
 type assoc = Left | Right | NoAssoc
 
+(** Returns the separator, the priority (as an integer) and the associativity of
+    a variadic operator. *)
 let varop_info v = match v with
-| Tuple -> ", ", 0, NoAssoc
-| Cup -> " | ", 2, NoAssoc
-| Cap -> " & ", 3, NoAssoc
+  | Tuple -> ", ", 0, NoAssoc
+  | Cup -> " | ", 2, NoAssoc
+  | Cap -> " & ", 3, NoAssoc
 
+(** Returns the separator, the priority (as an integer) and the associativity of
+    a binary operator. *)
 let binop_info b = match b with
-| Arrow -> " -> ", 1, Right
-| Diff -> " \\ ", 4, Left
+  | Arrow -> " -> ", 1, Right
+  | Diff -> " \\ ", 4, Left
 
+(** Returns the separator, the priority (as an integer) and the associativity of
+    a unary operator. *)
 let unop_info u = match u with
-| Neg -> "~", 5, NoAssoc
+  | Neg -> "~", 5, NoAssoc
 
+(** Maximum priority *)
 let max_prec = 100
+
+(** Minimum priority *)
 let min_prec = (-1)
 
-let need_parentheses prec assoc (_,prec',assoc') =
+(** [need_parentheses lvl assoc info] returns [true] if the operator described
+    by [info] needs parentheses for the current printing level [lvl] and the
+    current associativity [assoc].
+*)
+let need_parentheses (prec:int) assoc ((_:string),prec',assoc') =
   prec' < prec || prec' = prec && (assoc' <> assoc || assoc' = NoAssoc)
 
+(** [fprintf lvl assoc info fmt f …] works as [Format.fprintf] but will add
+    parentheses around the formatted output if required by [lvl] [assoc] and
+    [info].
+*)
 let fprintf prec assoc opinfo fmt f =
   if need_parentheses prec assoc opinfo
   then Format.fprintf fmt ("("^^f^^")")

--- a/src/lib/sstt/types/printer/printer.ml
+++ b/src/lib/sstt/types/printer/printer.ml
@@ -28,7 +28,7 @@ end
 
 type builtin =
   | Empty | Any | AnyTuple | AnyEnum | AnyTag | AnyInt
-  | AnyArrow | AnyRecord | AnyTupleComp of int | AnyTagComp of TagComp.Tag.t
+  | AnyArrow | AnyRecord | AnyTupleComp of int | AnyTagComp of Tag.t
 type 'c t' = { main : 'c descr' ; defs : 'c def' list }
 and 'c def' = NodeId.t * 'c descr'
 and 'c descr' = { op : 'c op' ; ty : Ty.t }
@@ -39,7 +39,7 @@ and 'c op' =
   | Builtin of builtin
   | Var of Var.t
   | Enum of Enums.Atom.t
-  | Tag of TagComp.Tag.t * 'c descr'
+  | Tag of Tag.t * 'c descr'
   | Interval of Z.t option * Z.t option
   | Record of (Label.t * 'c descr' * bool) list * bool
   | Varop of varop * 'c descr' list
@@ -58,12 +58,12 @@ type custom = CDef of NodeId.t * (Ty.t, descr, custom) cparams list | CNode of N
 type extracted_params = (Ty.t, Ty.t, Ty.t) cparams list
 module type PrinterExt = sig
   type t
-  val tag : TagComp.Tag.t
+  val tag : Tag.t
   val extractors : (Ty.t -> extracted_params option) list
   val get : custom -> t
   val print : int -> assoc -> Format.formatter -> t -> unit
 end
-type custom' = CDef of NodeId.t * (Ty.t, (TagComp.Tag.t * custom') descr', custom') cparams list | CNode of NodeId.t
+type custom' = CDef of NodeId.t * (Ty.t, (Tag.t * custom') descr', custom') cparams list | CNode of NodeId.t
 
 type aliases = (Ty.t * string) list
 type extensions = (module PrinterExt) list
@@ -75,7 +75,7 @@ module VDMap = Map.Make(VD)
 
 module NIMap = Map.Make(NodeId)
 module NISet = Set.Make(NodeId)
-module TagMap = Map.Make(TagComp.Tag)
+module TagMap = Map.Make(Tag)
 
 let map_descr' fc f d = (* Assumes f preserves semantic equivalence *)
   let rec aux d =

--- a/src/lib/sstt/types/printer/printer.mli
+++ b/src/lib/sstt/types/printer/printer.mli
@@ -21,7 +21,7 @@ end
 
 type builtin =
 | Empty | Any | AnyTuple | AnyEnum | AnyTag | AnyInt
-| AnyArrow | AnyRecord | AnyTupleComp of int | AnyTagComp of TagComp.Tag.t
+| AnyArrow | AnyRecord | AnyTupleComp of int | AnyTagComp of Tag.t
 type 'c t' = { main : 'c descr' ; defs : 'c def' list }
 and 'c def' = NodeId.t * 'c descr'
 and 'c descr' = { op : 'c op' ; ty : Ty.t }
@@ -32,7 +32,7 @@ and 'c op' =
 | Builtin of builtin
 | Var of Var.t
 | Enum of Enums.Atom.t
-| Tag of TagComp.Tag.t * 'c descr'
+| Tag of Tag.t * 'c descr'
 | Interval of Z.t option * Z.t option
 | Record of (Label.t * 'c descr' * bool) list * bool
 | Varop of varop * 'c descr' list
@@ -51,7 +51,7 @@ type custom = CDef of NodeId.t * (Ty.t, descr, custom) cparams list | CNode of N
 type extracted_params = (Ty.t, Ty.t, Ty.t) cparams list
 module type PrinterExt = sig
     type t
-    val tag : TagComp.Tag.t
+    val tag : Tag.t
     val extractors : (Ty.t -> extracted_params option) list
     val get : custom -> t
     val print : int -> assoc -> Format.formatter -> t -> unit

--- a/src/lib/sstt/types/subst.mli
+++ b/src/lib/sstt/types/subst.mli
@@ -1,30 +1,72 @@
+(** Type substitutions *)
+
 open Core
 
 type t
+(** The type of type substitutions. Substitution are quasi-constant mappings
+      that map every variable to itself (as a type), except for a finite set of
+      variables.
+
+    The {i domain} of a substitution is the set of variables for which it is not
+    constant (see {!domain}).
+*)
 
 val identity : t
-val singleton : Var.t -> Ty.t -> t
-val of_list : (Var.t * Ty.t) list -> t
+(** The identity substitutions which maps every variable to itself. *)
 
-(** [refresh ~names vs] returns a substitution mapping each variable
-in [vs] to a fresh one. If [names] is omitted, each fresh variable
-will have the same name as the original one. *)
+val singleton : Var.t -> Ty.t -> t
+(** [singleton v t] is the substitutions that maps every variable to itself,
+    except [v] which is mapped to [t]. *)
+
+val of_list : (Var.t * Ty.t) list -> t
+(** Creates a substitution from the given list of variables. If a variable
+    occurs several times, the last occurrence is used.
+*)
+
 val refresh : ?names:(Var.t -> string) -> VarSet.t -> t * t
+(** [refresh ~names vs] returns a substitution mapping each variable
+    in [vs] to a fresh one. If [names] is omitted, each fresh variable
+    will have the same name as the original one. *)
 
 val domain : t -> VarSet.t
+(** Returns the domain of a substitution, that is the set of variables for which
+    the substitution is not the identity.
+*)
+
 val bindings : t -> (Var.t * Ty.t) list
+(** Returns the substution as a list of bindings from variables to types.
+*)
+
+
 val find : t -> Var.t -> Ty.t
+(** Returns the type associated with a variable. This function always succeeds, and will return 
+    the type {m \alpha }, if the variable {m \alpha} is not in the domain of the substitution. *)
 
 val add : Var.t -> Ty.t -> t -> t
-val remove : Var.t -> t -> t
-val filter : (Var.t -> Ty.t -> bool) -> t -> t
-val map : (Ty.t -> Ty.t) -> t -> t
+(** Adds a new binding to the given substitution. If the new binding is the
+    identity for the given variable, the substitution is unchanged. *)
 
-(** [compose s2 s1] returns a substitution [s] such that applying [s]
-has the same effect as applying [s1] and then [s2]. *)
+val remove : Var.t -> t -> t
+(** Remove a variable from the domain of the substitution. *)
+
+val filter : (Var.t -> Ty.t -> bool) -> t -> t
+(** [filter p s] restricts the substitution to all variables of the domain for
+    which [p] returns [true].*)
+
+val map : (Ty.t -> Ty.t) -> t -> t
+(** [map f s] returns the substitution where [f] is applied to each type [t] in the domain of [s]. *)
+
 val compose : t -> t -> t
+(** [compose s2 s1] returns a substitution [s] such that applying [s]
+    has the same effect as applying [s1] and then [s2]. *)
 
 val equiv : t -> t -> bool
+(** Checks whether two substitutions are equivalent, that is, they have the same
+    domain and for each variable, the associated types are equivalent (using
+    {!Sstt.Ty.equiv}). *)
+
 val is_identity : t -> bool
+(** Checks whether the domain of the substitution is empty. *)
 
 val apply : t -> Ty.t -> Ty.t
+(** Applies the given susbtitution to the given type. *)

--- a/src/lib/sstt/types/tallying.mli
+++ b/src/lib/sstt/types/tallying.mli
@@ -1,22 +1,29 @@
+(** Tallying (unification modulo subtyping constraints). *)
+
 open Core
 
 type constr = Ty.t * Ty.t
+(** The type of a tallying constraint. A constraint [(s, t)] means
+    that we want to find all substitutions for variables of [s] and [t] 
+    such that [Ty.leq s t].
+*)
+
 
 (** [tally mono constrs] returns all solutions to the tallying instance
-[constrs], considering that variables in [mono] cannot be substituted.
-The solutions returned do not feature any fresh type variable:
-the type variables already present in [constrs] are reused. *)
+    [constrs], considering that variables in [mono] cannot be substituted.
+    The solutions returned do not feature any fresh type variable:
+    the type variables already present in [constrs] are reused. *)
 val tally : VarSet.t -> constr list -> Subst.t list
 
 (** [tally_with_order compare mono constrs] is the same as [tally mono constrs],
-but using the total order [compare] over type variables. The solutions returned
-are such that a variable cannot be substituted by a type featuring a smaller
-non-monomorphic variable at top-level. *)
+    but using the total order [compare] over type variables. The solutions returned
+    are such that a variable cannot be substituted by a type featuring a smaller
+    non-monomorphic variable at top-level. *)
 val tally_with_order : (Var.t -> Var.t -> int) -> VarSet.t -> constr list -> Subst.t list
 
 (** [tally_with_priority lst mono constrs] is the same as [tally mono constrs],
-but using an order that will preserve variables in [lst] when possible.
-The solutions returned are such that a variable in [lst] cannot be substituted
-by a type featuring, at top-level, a non-monomorphic variable further in [lst]
-or not in [lst]. The list of variables [lst] should not have duplicates. *)
+    but using an order that will preserve variables in [lst] when possible.
+    The solutions returned are such that a variable in [lst] cannot be substituted
+    by a type featuring, at top-level, a non-monomorphic variable further in [lst]
+    or not in [lst]. The list of variables [lst] should not have duplicates. *)
 val tally_with_priority : Var.t list -> VarSet.t -> constr list -> Subst.t list

--- a/src/lib/sstt/types/transform.mli
+++ b/src/lib/sstt/types/transform.mli
@@ -1,11 +1,25 @@
+(** Type transformation and simplification *)
+
 open Core
 
-(** [transform f ty] returns the type obtained by applying [f]
-on the full descriptor of [ty], and on the full descriptor of
-every node in the result recursively. It uses a cache to avoid
-calling [f] twice on the same descriptor. *)
-val transform : (VDescr.t -> VDescr.t) -> Ty.t -> Ty.t
 
-(** [simplify ty] returns a type equivalent to [ty] but where
-atoms have been merged together when possible. *)
+val transform : (VDescr.t -> VDescr.t) -> Ty.t -> Ty.t
+(** [transform f ty] returns the type obtained by applying [f] on the full
+      descriptor of [ty], and on the full descriptor of every node in the result
+      recursively. It uses a cache to avoid calling [f] twice on the same
+      descriptor.
+
+    Note that the function will may not terminate if [f] creates arbitrarily
+    many new descriptors. For instance, if [f] is the function that maps
+    singleton intervals to their successors: 
+    {math 
+    \texttt{f : } (n\texttt{..}n)\mapsto (n+1\texttt{..}n+1)
+    }
+    then when applied to a type {m t\equiv\texttt{(0..0)}}, [transform f t] will
+    not terminate.
+*)
+
 val simplify : Ty.t -> Ty.t
+(** [simplify ty] returns a type equivalent to [ty] but where
+    atoms of all components have been merged together when possible.    
+*)

--- a/src/lib/sstt/types/types.ml
+++ b/src/lib/sstt/types/types.ml
@@ -1,9 +1,25 @@
+(** {1 Operations on types }*)
+
+module Subst = Subst
+
+module Op = Op
+
+module Transform = Transform
+
+module Tallying = Tallying
+
+(** {1 Pretty-printing of types} *)
+
 module Prec = Prec
 module Printer = Printer
-module Tallying = Tallying
-module Subst = Subst
-module Op = Op
-module Transform = Transform
+
+(** {1 Extensions } 
+
+This modules provides several common data-types, encoded as tagged type with a
+particular tag.
+*)
+
+
 module Extensions = struct
   module Lists = Lists
   module Strings = Strings

--- a/sstt.opam
+++ b/sstt.opam
@@ -9,6 +9,7 @@ homepage: "https://github.com/E-Sh4rk/sstt"
 bug-reports: "https://github.com/E-Sh4rk/sstt/issues"
 depends: [
   "ocaml" {>= "5.3.0"}
+  "mdx" {with-test}
   "dune" {>= "3.17"}
   "zarith"
   "odoc" {with-doc}


### PR DESCRIPTION
This commit does the following:
- add a lot of documentation to the public interface
- rename tagged.ml to indexed.ml
- tries to have a consistent terminology between components, indexed components (tuples, tags), ...
- add examples in an custom index.mld file. The examples require the mdx tool (added as a dependency for tests) and can be updated using dune build @runtest
- refactor sigs.ml. In particular it removes useless module types, and tries to use a trait-like approach, factorising all common function in function interfaces and including them.