### PR TITLE
Implement `hash : t -> int` for all modules

### DIFF
--- a/src/lib/sstt/core/components/arrows.ml
+++ b/src/lib/sstt/core/components/arrows.ml
@@ -12,6 +12,7 @@ module Atom(N:Node) = struct
   let compare (s1,t1) (s2,t2) =
     N.compare s1 s2 |> ccmp
       N.compare t1 t2
+  let hash (n1, n2) = Hash.mix (N.hash n1) (N.hash n2)
 end
 
 module Make(N:Node) = struct
@@ -29,7 +30,6 @@ module Make(N:Node) = struct
   let cup = Bdd.cup
   let neg = Bdd.neg
   let diff = Bdd.diff
-
   let rec psi t1 t2 ps =
     N.is_empty t1 || N.is_empty t2 ||
     match ps with
@@ -71,4 +71,6 @@ module Make(N:Node) = struct
 
   let equal = Bdd.equal
   let compare = Bdd.compare
+  let hash = Bdd.hash
+
 end

--- a/src/lib/sstt/core/components/records.ml
+++ b/src/lib/sstt/core/components/records.ml
@@ -40,6 +40,8 @@ module OTy(N:Node) = struct
   let compare (n1,b1) (n2,b2) = compare b1 b2 |> ccmp N.compare n1 n2
 
   let map_nodes f (n,b) = (f n, b)
+
+  let hash (n, b) = Hash.(mix (bool b) (N.hash n))
 end
 
 module Atom(N:Node) = struct
@@ -48,6 +50,9 @@ module Atom(N:Node) = struct
   type node = N.t
   type nonrec oty = node * bool
   type t = { bindings : oty LabelMap.t ; opened : bool }
+
+  let hash t = (* TODO FIX *)
+    Hash.(mix (bool t.opened) (Hashtbl.hash t.bindings))
   let map_nodes f t =
     { t with bindings = LabelMap.map (OTy.map_nodes f) t.bindings }
 
@@ -86,6 +91,9 @@ module Atom'(N:Node) = struct
   type node = N.t
   type nonrec oty = node * bool
   type t = { bindings : oty LabelMap.t ; opened : bool ; required : LabelSet.t option }
+  let hash t = (* TODO FIX *)
+    Hash.(mix3 (bool t.opened) (Hashtbl.hash t.bindings) (Hashtbl.hash t.required))
+
   let dom t = LabelMap.bindings t.bindings |> List.map fst |> LabelSet.of_list
   let find lbl t =
     match LabelMap.find_opt lbl t.bindings with
@@ -261,4 +269,5 @@ module Make(N:Node) = struct
 
   let equal = Bdd.equal
   let compare = Bdd.compare
+  let hash = Bdd.hash
 end

--- a/src/lib/sstt/core/components/tags.ml
+++ b/src/lib/sstt/core/components/tags.ml
@@ -14,7 +14,8 @@ module Atom(N:Node) = struct
     Tag.equal t1 t2 && N.equal n1 n2
   let compare (t1,n1) (t2,n2) =
     Tag.compare t1 t2 |> ccmp
-    N.compare n1 n2
+      N.compare n1 n2
+  let hash (t, n) = Hash.mix (Tag.hash t) (N.hash n)
 end
 
 module MakeC(N:Node) = struct
@@ -25,6 +26,7 @@ module MakeC(N:Node) = struct
   type t = Tag.t * Bdd.t
   type node = N.t
 
+  let hash (tag, t) = Hash.mix (Tag.hash tag) (Bdd.hash t)
   let any n = n, Bdd.any
   let empty n = n, Bdd.empty
 
@@ -32,7 +34,7 @@ module MakeC(N:Node) = struct
 
   let tag (tag,_) = tag
   let index = tag
-  
+
   let check_tag tag tag' =
     if Tag.equal tag tag' |> not then
       raise (Invalid_argument "Heterogeneous tags.")
@@ -67,8 +69,8 @@ module MakeC(N:Node) = struct
   let dnf (_,t) = Bdd.dnf t |> Dnf.mk
   let of_dnf tag dnf =
     dnf |> List.iter (fun (ps,ns,_) ->
-      ps |> List.iter (fun a -> check_tag tag (Atom.tag a)) ;
-      ns |> List.iter (fun a -> check_tag tag (Atom.tag a))
+        ps |> List.iter (fun a -> check_tag tag (Atom.tag a)) ;
+        ns |> List.iter (fun a -> check_tag tag (Atom.tag a))
       ) ;
     tag, Dnf.mk dnf |> Bdd.of_dnf
 

--- a/src/lib/sstt/core/components/tuples.ml
+++ b/src/lib/sstt/core/components/tuples.ml
@@ -13,6 +13,8 @@ module Atom(N:Node) = struct
     List.equal N.equal t1 t2
   let compare t1 t2 =
     List.compare N.compare t1 t2
+
+  let hash = Hash.list N.hash 
 end
 
 module MakeC(N:Node) = struct
@@ -22,6 +24,7 @@ module MakeC(N:Node) = struct
 
   type t = int * Bdd.t
   type node = N.t
+  let hash (len, t) = Hash.mix (Hash.int len) (Bdd.hash t)
 
   let any n = n, Bdd.any
   let empty n = n, Bdd.empty

--- a/src/lib/sstt/core/descr.ml
+++ b/src/lib/sstt/core/descr.ml
@@ -45,6 +45,10 @@ module Make(N:Node) = struct
     intervals = Intervals.empty
   }
 
+  let hash t =
+    Hash.(mix 
+            (mix3 (Enums.hash t.enums) (Intervals.hash t.intervals) (Arrows.hash t.arrows))    
+            (mix3 (Records.hash t.records) (Tuples.hash t.tuples) (Tags.hash t.tags)))
   let mk_enums a = { empty with enums = a }
   let mk_tags a = { empty with tags = a }
   let mk_arrows a = { empty with arrows = a }

--- a/src/lib/sstt/core/node.ml
+++ b/src/lib/sstt/core/node.ml
@@ -120,7 +120,7 @@ include (struct
     let has_def t = Option.is_some t.def
     let def t = t.def |> Option.get
 
-    let hash t = Hashtbl.hash t.id
+    let hash t = Hash.int t.id
     let compare t1 t2 = Int.compare t1.id t2.id
     let equal t1 t2 = (t1.id = t2.id)
 

--- a/src/lib/sstt/core/sigs.ml
+++ b/src/lib/sstt/core/sigs.ml
@@ -8,6 +8,18 @@ module type Comparable = sig
 
   val equal : t -> t -> bool
   (** Equality, [equal a b] is equivalent to [compare a b = 0]. *)
+
+  val hash : t -> int
+  (** Hashing, [hash] is consistent with equality, that is
+      [equal a b] implies [hash a = hash b].
+  *)
+end
+
+module type ComparableH = sig
+  type t
+  include Comparable with type t := t
+  val hash : t -> int
+
 end
 
 module type TyBase = sig

--- a/src/lib/sstt/core/utils/hash.ml
+++ b/src/lib/sstt/core/utils/hash.ml
@@ -1,0 +1,80 @@
+let const0 = 0x278dde6d (* 2^32 * golden ratio, mod 2^30 *)
+let const1 = 0x3f4a7c15 (* from SplitMix64 *)
+let const2 = 0x27d4eb2f (* from XXHash *)
+let const3 = 0x165667b1 (* from Murmur3 *)
+
+
+(* From Boost standard library, mod 2^30 *)
+let[@inline always] mix h1 h2 =
+  (h1 lxor (h2 + const0 + (h1 lsl 6) + (h1 lsr 2))) land 0x3fffffff
+
+let[@inline always] mix3 h1 h2 h3 =
+  mix h1 (mix h2 h3)
+let[@inline always] int_of_bool = (* OCaml compiles this to nop *) 
+  function false -> 0
+         | true -> 1
+let int i = mix const0 i
+let[@inline always] bool b = int (int_of_bool b)
+
+let list h l = (* use for small lists *)
+  let rec loop acc l =
+    match l with
+      [] -> acc
+    | e :: ll -> loop (mix acc (h e)) ll
+  in
+  loop const3 l
+
+(* hash.ml cannot depend on sigs.ml, it would introduce a cyclic dependency 
+*)
+module type Comparable =
+sig
+  include Set.OrderedType
+  include Hashtbl.HashedType with type t := t
+end
+
+module List(X : Comparable) : sig
+  type t = (X.t * int) list
+  include Comparable with type t := t
+  val ($::) : X.t -> t -> t
+  val of_list : X.t list -> t
+  val map : (X.t -> X.t) -> t -> t
+  val to_list : t -> X.t list
+  val filter : (X.t -> bool) -> t -> t
+  val for_all : (X.t -> bool) -> t -> bool
+end = struct
+
+  type t = (X.t * int) list
+
+  let compare_hash (x1, h1) (x2, h2) =
+    let c = Int.compare h1 h2 in
+    if c <> 0 then c else X.compare x1 x2
+
+  let equal_hash (x1, h1) (x2, h2) =
+    h1 == h2 && X.equal x1 x2
+  let compare = List.compare compare_hash
+  let equal = List.equal equal_hash
+
+  let[@inline always] hash = function
+      [] -> const0
+    | (_, h) :: _ -> h
+
+  let[@inline always] ($::) x l = (x, mix (hash l) (X.hash x))::l
+
+  let of_list = List.fold_left (fun acc e -> e $:: acc) []
+  let map f l =
+    let rec loop l =
+      match l with
+        [] -> []
+      | (e, _) :: ll -> (f e) $:: loop ll
+    in loop l
+
+  let to_list = List.map fst
+
+  let rec filter f = function 
+    | [] -> []
+    | (e, _) :: ll -> if f e then e $:: filter f ll else filter f ll
+
+  let rec for_all f = function
+    | [] -> true
+    | (e, _) :: ll -> (f e) && for_all f ll
+end

--- a/src/lib/sstt/core/utils/id.ml
+++ b/src/lib/sstt/core/utils/id.ml
@@ -31,7 +31,7 @@ module NamedIdentifier () : NamedIdentifier = struct
 
   let mk name =  (next_id (), name)
   let name (_, name) = name
-  let hash (i,_) = Hashtbl.hash i
+  let hash (i,_) = Hash.int i
   let compare (i1,_) (i2,_) = Int.compare i1 i2
   let equal (i1,_) (i2,_) = (i1 == i2)
   let pp fmt (_,name) = Format.fprintf fmt "%s" name

--- a/src/lib/sstt/core/utils/indexed.ml
+++ b/src/lib/sstt/core/utils/indexed.ml
@@ -1,14 +1,10 @@
 open Sigs
 open Sstt_utils
 
-module type Tag = sig
-  include Comparable
-end
-
 module type IdxComp = sig
   type t
   type node
-  module Index : Comparable
+  module Index : ComparableH
   val any : Index.t -> t
   val empty : Index.t -> t
   val index : t -> Index.t
@@ -25,16 +21,22 @@ end
 
 module Make(C : IdxComp) = struct
 
-  type t = { map : C.t list; others : bool }
+  type t = { map : (C.t * int) list; others : bool }
   (* When others is [true], missing tags are mapped to Any
      When others is [false], missing tags are mapped to Empty
   *)
 
-  let mk a =
-    { map = [a] ; others = false }
+  module HList = Hash.List(C)
+  let hash t = Hash.mix (HList.hash t.map) (Bool.hash t.others)
 
-  let of_comp_list =
-    List.sort_uniq (fun a b -> C.(Index.compare (index a) (index b)))
+  let ($::) = HList.($::)
+  let mk a =
+    { map = a $:: [] ; others = false }
+
+  let of_comp_list l =
+    l
+    |> List.sort_uniq (fun a b -> C.(Index.compare (index b) (index a)))
+    |> HList.of_list
 
   let of_components (ts, others) =
     let map = of_comp_list ts in
@@ -44,7 +46,7 @@ module Make(C : IdxComp) = struct
       let map = of_comp_list cs in
       { map ; others=false }
     else
-      let map = of_comp_list cs |> List.map C.neg in
+      let map = of_comp_list cs |> HList.map C.neg in
       { map ; others=true }
 
   let any = { map = [] ; others = true }
@@ -52,26 +54,26 @@ module Make(C : IdxComp) = struct
 
   let neg t =
     let others = not t.others in
-    let map = List.map C.neg t.map in
+    let map = HList.map C.neg t.map in
     { map ; others }
 
   let [@inline always] (@?) o l =
     match o with
       None -> l
-    | Some e -> e :: l
+    | Some e -> e $:: l
 
   let[@inline always] op empty1 empty2 missing1 missing2 comb12 combo t1 t2 =
     let rec loop l1 l2 =
       match l1, l2 with
       | [], _ -> empty1 l2
       | _, [] -> empty2 l1
-      | a1 :: ll1, a2 :: ll2 ->
+      | (a1,_) :: ll1, (a2,_) :: ll2 ->
         let e1 = C.index a1 in
         let e2 = C.index a2 in
         let c = C.Index.compare e1 e2 in
         if c < 0 then (missing2 a1) @? loop ll1 l2
         else if c > 0 then (missing1 a2) @? loop l1 ll2
-        else (comb12 a1 a2)::loop ll1 ll2
+        else (comb12 a1 a2)$::loop ll1 ll2
     in
     let others = combo t1.others t2.others in
     { map = loop t1.map t2.map; others }
@@ -96,42 +98,42 @@ module Make(C : IdxComp) = struct
       (||) t1 t2
   let diff t1 t2 =
     op 
-      (if t1.others then List.map C.neg else cst_nil)
+      (if t1.others then HList.map C.neg else cst_nil)
       (if not t2.others then Fun.id else cst_nil)
       (if t1.others then (fun x -> Some (C.neg x)) else cst_none)
       (if not t2.others then Option.some else cst_none)
       C.diff
       (fun b1 b2 -> b1 && not b2) t1 t2
   let is_empty t =
-    not t.others && List.for_all C.is_empty t.map
+    not t.others && HList.for_all C.is_empty t.map
 
   let direct_nodes t =
-    List.concat_map C.direct_nodes t.map
+    List.concat_map (fun (c, _) -> C.direct_nodes c) t.map
 
   let map_nodes f t =
-    let map = List.map (C.map_nodes f) t.map in
+    let map = HList.map (C.map_nodes f) t.map in
     { map ; others=t.others }
 
   let simplify t =
     let t_is_empty t = C.is_empty t in
     let t_is_any t = C.neg t |> C.is_empty in
-    let map = List.map C.simplify t.map in
+    let map = HList.map C.simplify t.map in
     let p = if t.others then t_is_any else t_is_empty in
-    let map = List.filter (fun t -> p t |> not) map in
+    let map = HList.filter (fun t -> p t |> not) map in
     { map ; others = t.others }
 
-  let components t = (t.map, t.others)
+  let components t = (List.map fst t.map, t.others)
 
   let destruct t =
     if t.others then
-      (false, List.map C.neg t.map)
+      (false, List.map (fun (c, _) -> C.neg c) t.map)
     else
-      (true,  t.map)
+      (true,  HList.to_list t.map)
 
   let rec find_tag tag l =
     match l with
       [] -> None
-    | a :: ll -> 
+    | (a,_) :: ll -> 
       let c = C.Index.compare (C.index a) tag in
       if c < 0 then find_tag tag ll
       else if c > 0 then None
@@ -144,15 +146,13 @@ module Make(C : IdxComp) = struct
       else  C.empty tag
 
   let map f t =
-    let map = List.map f t.map in
+    let map = HList.map f t.map in
     { t with map }
 
   let equal t1 t2 =
-    Bool.equal t1.others t2.others &&
-    try
-      List.for_all2 C.equal t1.map t2.map
-    with _ -> false
+    Bool.equal t1.others t2.others && HList.equal t1.map t2.map
+
   let compare t1 t2 =
     Bool.compare t1.others t2.others |> ccmp
-      (List.compare C.compare) t1.map t2.map
+      HList.compare t1.map t2.map
 end

--- a/src/lib/sstt/core/vdescr.ml
+++ b/src/lib/sstt/core/vdescr.ml
@@ -67,4 +67,5 @@ module Make(N:Node) = struct
 
   let equal = Bdd.equal
   let compare = Bdd.compare
+  let hash = Bdd.hash
 end

--- a/src/lib/sstt/types/transform.ml
+++ b/src/lib/sstt/types/transform.ml
@@ -1,25 +1,25 @@
 open Core
 open Sstt_utils
 
-module VDMap = Map.Make(VDescr)
+module VDHash = Hashtbl.Make(VDescr)
 
 type ctx = {
-  mutable cache : Var.t VDMap.t ;
+  cache : Var.t VDHash.t ;
   mutable eqs : (Var.t * Ty.t) list
 }
 
 let transform f t =
   let ctx = {
-    cache = VDMap.empty ;
+    cache = VDHash.create 8 ;
     eqs = []
   } in
   let rec aux t =
     let vd = Ty.def t in
-    match VDMap.find_opt vd ctx.cache with
+    match VDHash.find_opt ctx.cache vd with
     | Some v -> v
     | None ->
       let v = Var.mk "" in
-      ctx.cache <- VDMap.add vd v ctx.cache ;
+      VDHash.add ctx.cache vd v ;
       let vd = f vd |> VDescr.map_nodes aux_ty in
       ctx.eqs <- (v, Ty.of_def vd)::ctx.eqs ;
       v
@@ -32,11 +32,11 @@ let transform f t =
 
 let regroup_arrows conjuncts =
   let merge_conjuncts (l,r) (l',r') =
-      if Ty.equiv l l'
-      then Some (l, Ty.cap r r')
-      else if Ty.equiv r r'
-      then Some (Ty.cup l l', r)
-      else None
+    if Ty.equiv l l'
+    then Some (l, Ty.cap r r')
+    else if Ty.equiv r r'
+    then Some (Ty.cup l l', r)
+    else None
   in
   merge_when_possible merge_conjuncts conjuncts
 let regroup_arrows (ps,ns,b) =
@@ -58,11 +58,11 @@ let regroup_records (ps,ns,b) =
   let open Records.Atom in
   (* Convert negative atoms to positive ones when possible *)
   let ps',ns = ns |> List.partition_map (fun r ->
-    match LabelMap.to_list r.bindings with
-    | [lbl,oty] when r.opened ->
-      Either.Left ({ r with bindings=LabelMap.singleton lbl (Ty.O.neg oty) })
-    | _ -> Either.Right r
-  ) in
+      match LabelMap.to_list r.bindings with
+      | [lbl,oty] when r.opened ->
+        Either.Left ({ r with bindings=LabelMap.singleton lbl (Ty.O.neg oty) })
+      | _ -> Either.Right r
+    ) in
   (* Regroup positive conjuncts *)
   (regroup_records (ps'@ps), ns, b)
 let merge_record_lines (ps1,ns1,b1) (ps2,ns2,b2) =
@@ -70,9 +70,9 @@ let merge_record_lines (ps1,ns1,b1) (ps2,ns2,b2) =
   match ps1, ps2, ns1, ns2 with
   | [p1], [p2], [], [] when b1=b2 && p1.opened=p2.opened ->
     begin match LabelMap.to_list p1.bindings, LabelMap.to_list p2.bindings with
-    | [lbl1,oty1], [lbl2,oty2] when Label.equal lbl1 lbl2 ->
-      Some ([{ p1 with bindings=LabelMap.singleton lbl1 (Ty.O.cup oty1 oty2) }],[],b1)
-    | _, _ -> None
+      | [lbl1,oty1], [lbl2,oty2] when Label.equal lbl1 lbl2 ->
+        Some ([{ p1 with bindings=LabelMap.singleton lbl1 (Ty.O.cup oty1 oty2) }],[],b1)
+      | _, _ -> None
     end
   | _, _, _, _ -> None
 
@@ -82,10 +82,10 @@ let regroup_tuples conjuncts =
 let regroup_tuples (ps,ns,b) =
   (* Convert negative atoms to positive ones when possible *)
   let ps',ns = ns |> List.partition_map (fun lst ->
-    match lst with
-    | [ty] -> Either.Left [Ty.neg ty]
-    | _ -> Either.Right lst
-  ) in
+      match lst with
+      | [ty] -> Either.Left [Ty.neg ty]
+      | _ -> Either.Right lst
+    ) in
   (* Regroup positive conjuncts *)
   (regroup_tuples (ps'@ps), ns, b)
 let merge_tuple_lines (ps1,ns1,b1) (ps2,ns2,b2) =
@@ -110,13 +110,13 @@ let simpl_tags t = Tags.map (fun c -> TagComp.as_atom c |> TagComp.mk) t
 let simpl_descr d =
   let open Descr in
   d |> components |> List.map (function
-    | Intervals i -> Intervals i
-    | Enums e -> Enums e
-    | Tags t -> Tags (simpl_tags t)
-    | Arrows a -> Arrows (simpl_arrows a)
-    | Tuples t -> Tuples (simpl_tuples t)
-    | Records r -> Records (simpl_records r)
-  ) |>  Descr.of_components
+      | Intervals i -> Intervals i
+      | Enums e -> Enums e
+      | Tags t -> Tags (simpl_tags t)
+      | Arrows a -> Arrows (simpl_arrows a)
+      | Tuples t -> Tuples (simpl_tuples t)
+      | Records r -> Records (simpl_records r)
+    ) |>  Descr.of_components
 
 let simpl_vdescr = VDescr.map simpl_descr
 


### PR DESCRIPTION
Each component as well as `Descr` and `Vdescr` now support an efficient hash function.
Partial hashes are stored in the data-structure.
This allows to create efficient `Hashtbl` of `VDescr`, and use them instead of `Map.Make(VDescr)` (except for the subtyping where the persistent nature of Map is important to restore a previous state).

This improves performances slightly (~10%), mainly because now comparisons are much faster (since they take the hash into account).

Note: the only hashsing that is not incremental is the hashing of record atoms, where the default polymorphic hash (`Hashtbl.hash`) is used. This does not seem to hurt since in our examples, atoms are small, and the performances can be recovered if necessary by using the same approach as for tags (sorted list of bindings incrementally hashed).