### PR TITLE
Implement a hash based cache for the subtyping algorithm

### DIFF
--- a/src/lib/sstt/core/utils/bttable.ml
+++ b/src/lib/sstt/core/utils/bttable.ml
@@ -1,0 +1,122 @@
+module Make (V : Hashtbl.HashedType) (R : sig type t val equal : t -> t-> bool end): sig
+
+  (** 
+     Hash table specialized for computations over co-inductive structures.
+
+      This table can be used for computations over co-inductive structures whose
+      results depend on an initial guess. When exploring a co-inductive value
+       [v : V.t], we say that [v] is [Active], if it is being explored and the
+      exploration is not finished. The API is as follows:
+     - first, one looks for [v] in the table, using [find ~default:r table v]
+
+        - if [v] is not in the table, it associates an initial result [r : R.t],
+            returns [None] and [v] becomes active. The exploration of
+            [v] can continue.
+        - if [v] is in the table, it means it is encountered again. The initial
+            value stored is returned as [Some r] and all values that became
+            active after [v] and are still active are recorded. 
+            These are the dependencies of [v].
+
+     - when returning from the initial exploration of [v] with a computed
+        result [r'], one needs to update the result [update table v r']:
+        - if [R.equal r r'] then the initial guess was correct, and all
+              dependencies are left as-is
+        - otherwise, the dependencies of [v] are removed from the table: they
+              were computed while making the (wrong) hypothesis that the result for
+              [v] was [r], while it is [r']. Later calls to [find ~default:r table
+              v] will return [r'] unless it is itself invalidated.
+
+
+      {ocaml[ let rec explore table v =
+
+        match find ~default:r table v with (* if [v] is not [Active] yet it
+        binds it to [d] in the table *)
+        | Some r -> r                     (* [v] was bound to some value *)
+        | None ->
+          let r' = (* COMPUTATION, may call explore recursively *) in
+
+          (* this will invalidate the dependencies if [not (R.equal r r')] *)
+          update table v r'
+
+      ]}
+  *)
+
+  type t
+  (** The type of the table.*)
+
+  exception InvalidAccess
+  (** Raised if a entry is used more than once. *)
+
+  val create : unit -> t
+  (** Creates an empty table *)
+
+  val clear : t -> unit
+  (** Clears the table. *)
+
+  val find : default:R.t -> t -> V.t -> R.t option
+  (** Retrieves the result associated with a value.
+      If the value is not in the table, the supplied [default] result
+      is added and a entry is returned.
+  *)
+
+  val update : t -> V.t -> R.t -> unit
+  (** Updates the value associated with the value that created the entry.
+        If the supplied value is not equal to the original one, all values in
+        the table whose result dependend on the original result are removed from
+        the table.
+
+      @raise InvalidAccess if the value is not already in the table.
+  *)
+
+end = struct
+  module H = Hashtbl.Make (V)
+
+  exception InvalidAccess
+
+  type entry = {
+    mutable active : bool;            (* status of the entry *)
+    mutable dependencies : V.t list;  (* the top of the stack at the time the entry was accessed *)
+    mutable result : R.t option;      (* the result stored in this entry *)
+  }
+  and t = {
+    table :  entry H.t;                 (* The table of all entrys *)
+    mutable stack : V.t list;           (* The stack of entrys. *)
+  }
+  let create () = { table = H.create 0; stack = []}
+  let clear t = H.clear t.table; t.stack <- []
+
+  let find ~default t key = 
+    match H.find_opt t.table key with
+    | None -> 
+      (* The key is not in the table start from scratch *)
+      let entry = { active = true; dependencies = []; result = Some default } in
+      t.stack <- key::t.stack;
+      H.add t.table key entry;
+      None
+
+    | Some entry -> 
+      (* We find an entry, if it is active, record the dependencies, that is
+         the current stack. *)
+      if entry.active then entry.dependencies <- t.stack;
+      entry.result
+
+  (* remove from the list until we find ourselves, this is when we where put
+     on the stack *)
+  let rec invalidate tbl deps stop = 
+    match deps with
+    | key :: prev when not (V.equal key stop) ->
+      H.remove tbl key;
+      invalidate tbl prev stop
+    | _ -> ()
+
+  let update t key r =
+    match H.find_opt t.table key, t.stack  with
+    | Some ({ active = true; result = Some old_r; _ } as cp), _::sstack ->
+      if not (R.equal r old_r) then begin
+        invalidate t.table cp.dependencies key;
+        cp.result <- Some r;
+      end;
+      t.stack <- sstack;
+      cp.active <- false
+    | _ -> raise InvalidAccess
+end


### PR DESCRIPTION
[This is a request for comments, I'm not advocating we include it right now but I found the data structure nice and will probably write something about it].

We use a custom-purpose hash-table which supports backtracking to a previous state. The API is pretty simple and follows the need of the subtyping algorithm (or indeed any backtracking algorithm that needs to revert its state to a previous point).

This improves the speed by about ~10% for two reasons.
    - hash tables are more efficient than maps
    - with the current persistent maps, when a type does *not* depend on an unknown type (it does not depend on a recursive type whose status we are checking) but is discovered during the exploration of that recursive type, then its result is invalidated regardless. For instance, with `t = (int list, t) | nil` when we come back to `t`, we store the fact that it is not empty, and remove from the cache the fact that `int list` is not empty (which is sound but not necessary since `int list` does not depend on `t`. Now if we are checking the outer-type: `(t, int list)` we check the type `int list` twice, once during `t` and once in the outer product.

The new cache tracks dependencies more finely, invalidating types
that are still on the stack when encountering an unknown recursive type.