### PR TITLE
Tallying refactor

### DIFF
--- a/src/lib/sstt/core/components/arrows.ml
+++ b/src/lib/sstt/core/components/arrows.ml
@@ -34,10 +34,7 @@ module Make(N:Node) = struct
     N.is_empty t1 || N.is_empty t2 ||
     match ps with
     | [] -> false
-    | (s1,s2)::ps ->
-      (N.leq t1 s1 || N.leq (List.map snd ps |> N.conj) (N.neg t2)) && (* optimisation *)
-      psi t1 (N.cap t2 s2) ps &&
-      psi (N.diff t1 s1) t2 ps
+    | (s1,s2)::ps ->  psi t1 (N.cap t2 s2) ps &&  psi (N.diff t1 s1) t2 ps
   let psi_strict t1 t2 ps =
     match ps with
     | [] -> true

--- a/src/lib/sstt/core/components/arrows.ml
+++ b/src/lib/sstt/core/components/arrows.ml
@@ -38,7 +38,7 @@ module Make(N:Node) = struct
 
   let is_clause_empty' ps (t1,t2) =
     N.leq t1 (List.map fst ps |> N.disj) &&
-    (ps == [] || psi t1 (N.neg t2) ps)
+    (List.is_empty ps || psi t1 (N.neg t2) ps)
   let is_clause_empty (ps,ns,b) =
     if b then List.exists (is_clause_empty' ps) ns else true
   let is_empty t = Bdd.for_all_lines is_clause_empty t

--- a/src/lib/sstt/core/components/arrows.ml
+++ b/src/lib/sstt/core/components/arrows.ml
@@ -34,15 +34,11 @@ module Make(N:Node) = struct
     N.is_empty t1 || N.is_empty t2 ||
     match ps with
     | [] -> false
-    | (s1,s2)::ps ->  psi t1 (N.cap t2 s2) ps &&  psi (N.diff t1 s1) t2 ps
-  let psi_strict t1 t2 ps =
-    match ps with
-    | [] -> true
-    | (s1,s2)::ps ->
-      psi t1 (N.cap t2 s2) ps && psi (N.diff t1 s1) t2 ps
+    | (s1,s2)::ps ->  psi (N.diff t1 s1) t2 ps && psi t1 (N.cap t2 s2) ps
+
   let is_clause_empty' ps (t1,t2) =
     N.leq t1 (List.map fst ps |> N.disj) &&
-    psi_strict t1 (N.neg t2) ps
+    (ps == [] || psi t1 (N.neg t2) ps)
   let is_clause_empty (ps,ns,b) =
     if b then List.exists (is_clause_empty' ps) ns else true
   let is_empty t = Bdd.for_all_lines is_clause_empty t

--- a/src/lib/sstt/core/components/records.ml
+++ b/src/lib/sstt/core/components/records.ml
@@ -181,11 +181,6 @@ module Make(N:Node) = struct
     else
       ([],[], false), 0
 
-
-  let odiff n1 n2 =
-    let d = ON.diff n1 n2 in
-    if ON.is_empty d then None else Some d
-
   let rec psi acc ss ts =
     List.exists ON.is_empty ss ||
     match ts with

--- a/src/lib/sstt/core/components/records.ml
+++ b/src/lib/sstt/core/components/records.ml
@@ -13,13 +13,14 @@ module OTy(N:Node) = struct
   let optional t = (t, true)
   let get (t,_) = t
 
-  let cap (n1, b1) (n2, b2) =
-    (N.cap n1 n2, b1 && b2)
-  let cup (n1, b1) (n2, b2) =
-    (N.cup n1 n2, b1 || b2)
-  let diff (n1, b1) (n2, b2) =
-    (N.diff n1 n2, b1 && not b2)
+  let cap (n1, b1) (n2, b2) = (N.cap n1 n2, b1 && b2)
+  let cap = fcap ~empty ~any ~cap
+  let cup (n1, b1) (n2, b2) = (N.cup n1 n2, b1 || b2)
+  let cup = fcup ~empty ~any ~cup
+  let diff (n1, b1) (n2, b2) = (N.diff n1 n2, b1 && not b2)
+  let diff = fdiff ~empty ~any ~diff
   let neg (n, b) = (N.neg n, not b)
+  let neg = fneg ~empty ~any ~neg
   let conj lst =
     let ns, bs = List.split lst in
     (N.conj ns, List.fold_left (&&) true bs)
@@ -73,12 +74,12 @@ module Atom(N:Node) = struct
     else
       OTy.absent::(to_tuple dom t)  
   let simplify t =
-    let not_any _ on = OTy.is_any on |> not in
-    let not_absent _ on = OTy.is_absent on |> not in
-    if t.opened then
-      { t with bindings = LabelMap.filter not_any t.bindings }
-    else
-      { t with bindings = LabelMap.filter not_absent t.bindings }
+    let is_default = 
+      if t.opened then OTy.is_any
+      else OTy.is_absent
+    in
+    let bindings = LabelMap.filter (fun _ on -> not (is_default on)) t.bindings in
+    if bindings == t.bindings then t else { t with bindings }
   let equal t1 t2 =
     t1.opened = t2.opened &&
     LabelMap.equal OTy.equal t1.bindings t2.bindings
@@ -103,13 +104,12 @@ module Atom'(N:Node) = struct
     | None when t.opened -> OTy.any
     | None -> OTy.absent
   let simplify t =
-    let bindings =
-      let not_any _ on = OTy.is_any on |> not in
-      let not_absent _ on = OTy.is_absent on |> not in
-      if t.opened
-      then LabelMap.filter not_any t.bindings
-      else LabelMap.filter not_absent t.bindings
+    let is_default = 
+      if t.opened then OTy.is_any
+      else OTy.is_absent
     in
+    let bindings = LabelMap.filter (fun _ on -> not (is_default on)) t.bindings in
+
     let required =
       match t.required with
       | None -> None
@@ -118,7 +118,8 @@ module Atom'(N:Node) = struct
         then None
         else Some (lbls |> LabelSet.filter (fun l -> find l t |> OTy.is_absent |> not))
     in
-    { t with bindings ; required }
+    if bindings == t.bindings && required == t.required then t else
+      { t with bindings ; required }
   let is_empty t =
     let is_empty_binding (_,on) = OTy.is_empty on in
     let required_ok =
@@ -168,17 +169,16 @@ module Make(N:Node) = struct
     let init = fun () -> List.init n (fun _ -> ON.empty) in
     mapn init ON.disj ps
 
-  let forall_distribute_diff f ss tt =
-    try
-      iter_distribute_comb (fun e -> if not (f e) then raise Exit) ON.diff ss tt;
-      true
-    with Exit -> false
+  let odiff n1 n2 =
+    let d = ON.diff n1 n2 in
+    if ON.is_empty d then None else Some d
+
   let rec psi ss ts =
-    List.exists ON.is_empty ss ||
     match ts with
     | [] -> false
     | tt::ts ->
-      forall_distribute_diff (fun ss -> psi ss ts) ss tt
+      forall_distribute_comb (fun ss -> psi ss ts) odiff ss tt
+
   let is_clause_empty (ps,ns,b) =
     if b then
       let dom = List.fold_left
@@ -192,7 +192,9 @@ module Make(N:Node) = struct
       | [],[] -> false
       | a::_,_ | [], a::_ ->
         let n = List.length a in
-        psi (conj n ps) ns
+        let ss = conj n ps in
+        List.exists ON.is_empty ss || psi ss ns
+
     else true
   let is_empty t = t |> Bdd.for_all_lines is_clause_empty
 

--- a/src/lib/sstt/core/components/tags.ml
+++ b/src/lib/sstt/core/components/tags.ml
@@ -81,7 +81,9 @@ module MakeC(N:Node) = struct
   let direct_nodes (_,t) = Bdd.atoms t |> List.concat_map Atom.direct_nodes
   let map_nodes f (tag,t) = tag, Bdd.map_nodes (Atom.map_nodes f) t
 
-  let simplify (tag,t) = (tag,Bdd.simplify equiv t)
+  let simplify ((tag,t) as n) = 
+    let t' = Bdd.simplify equiv t in
+    if t == t' then n else (tag, t')
 
   let equal (_,t1) (_,t2) = Bdd.equal t1 t2
   let compare (_,t1) (_,t2) = Bdd.compare t1 t2

--- a/src/lib/sstt/core/descr.ml
+++ b/src/lib/sstt/core/descr.ml
@@ -86,15 +86,19 @@ module Make(N:Node) = struct
   let of_component = set_component empty
   let of_components = List.fold_left set_component empty
 
-  let unop fato ftag ftup farr frec fint t = {
-    enums = fato t.enums ;
-    tags = ftag t.tags ;
-    tuples = ftup t.tuples ;
-    arrows = farr t.arrows ;
-    records = frec t.records ;
-    intervals = fint t.intervals
-  }
-
+  let unop fenu ftag ftup farr frec fint t = 
+    let enums = fenu t.enums in
+    let tags = ftag t.tags in
+    let tuples = ftup t.tuples in
+    let arrows = farr t.arrows in
+    let records = frec t.records in
+    let intervals = fint t.intervals in
+    if enums == t.enums && tags == t.tags && tuples == t.tuples &&
+       arrows = t.arrows && records == t.records && intervals == t.intervals
+    then t
+    else
+      { enums; tags; tuples; arrows; records; intervals }
+      
   let binop fato ftag ftup farr frec fint t1 t2 = {
     enums = fato t1.enums t2.enums ;
     tags = ftag t1.tags t2.tags ;
@@ -109,12 +113,12 @@ module Make(N:Node) = struct
   let diff = fdiff ~empty ~any ~diff:(binop Enums.diff Tags.diff Tuples.diff Arrows.diff Records.diff Intervals.diff)
   let neg = fneg ~empty ~any ~neg:(unop Enums.neg Tags.neg Tuples.neg Arrows.neg Records.neg Intervals.neg)
   let is_empty t = t == empty ||
-    Enums.is_empty t.enums &&
-    Intervals.is_empty t.intervals &&
-    Tags.is_empty t.tags &&
-    Tuples.is_empty t.tuples &&
-    Arrows.is_empty t.arrows &&
-    Records.is_empty t.records
+                   Enums.is_empty t.enums &&
+                   Intervals.is_empty t.intervals &&
+                   Tags.is_empty t.tags &&
+                   Tuples.is_empty t.tuples &&
+                   Arrows.is_empty t.arrows &&
+                   Records.is_empty t.records
 
   let direct_nodes t =
     [ Enums.direct_nodes t.enums ;

--- a/src/lib/sstt/core/node.ml
+++ b/src/lib/sstt/core/node.ml
@@ -188,11 +188,8 @@ include (struct
     let rec simplify t =
       if not t.simplified then begin
         let s_def = def t |> VDescr.simplify in
-        define ~simplified:true t s_def ;
-        s_def |> VDescr.direct_nodes |> List.iter simplify ;
-        match t.neg with
-        | None -> ()
-        | Some nt -> define ~simplified:true nt (VDescr.neg s_def)
+        define ~simplified:true t s_def;
+        s_def |> VDescr.direct_nodes |> List.iter simplify;
       end
 
     let dependencies t =

--- a/src/lib/sstt/core/sigs.ml
+++ b/src/lib/sstt/core/sigs.ml
@@ -525,6 +525,15 @@ module type Records = sig
                               and type node := node
                               and type atom := Atom.t
 
+  val dnf_line_to_tuple : (Atom.t list * Atom.t list * bool) -> (Atom.oty list list * Atom.oty list list * bool) * int
+  (** [dnf_line_to_tuple (ps, ns, b)] converts a line of a [Record] DNF to
+      a line of tuples. Each record is projected to a tuple that has as many components
+      as the number of distinct labels in [ps] and [ns]. The function also returns the size of the tuples
+      in the result (which is the number of labels plus one).
+
+      If the line is trivially empty, then the returned result is an empty line, with no
+      tuple elements and a size of 0.
+  *)
 
   (** @inline
 
@@ -553,7 +562,6 @@ module type Records = sig
   include OptComponentOps with type t := t
                            and type node := node
                            and type atom' := Atom'.t
-
 end
 
 (* Tuples *)
@@ -890,7 +898,7 @@ module type VDescr = sig
 
   (** {1 Explicit Disjunctive Normal Form }*)
 
-  module Dnf : sig 
+  module Dnf : sig
     (** Explicit Disjunctive Normal Forms (DNF) of variables and monomorphic descriptors. *)
 
     (** @inline *)

--- a/src/lib/sstt/types/transform.ml
+++ b/src/lib/sstt/types/transform.ml
@@ -25,8 +25,10 @@ let transform f t =
       v
   and aux_ty t = aux t |> Ty.mk_var in
   let v = aux t in
-  let res = Ty.of_eqs ctx.eqs |> VarMap.of_list in
-  VarMap.find v res
+  let res = Ty.of_eqs ctx.eqs in
+  res 
+  |> List.find_map (fun (v', t) -> if Var.equal v v' then Some t else None)
+  |> Option.get
 
 (* Type simplification *)
 

--- a/src/lib/utils/sstt_utils.ml
+++ b/src/lib/utils/sstt_utils.ml
@@ -51,34 +51,6 @@ let mapn default f lst =
   in
   if lst = [] then default () else aux f lst
 
-let subsets lst =
-  let rec aux acc s1 s2 lst =
-    match lst with
-    | [] -> (List.rev s1, List.rev s2)::acc
-    | e::lst ->
-      let acc' = aux acc s1 (e::s2) lst in
-      aux acc' (e::s1) s2 lst
-  in
-  aux [] [] [] lst
-
-let map_among_others' f lst =
-  let rec aux left right =
-    match right with
-      [] -> []
-    | c :: right -> (f left c right)::(aux (c::left) right)
-  in
-  aux [] lst
-
-let partitions n lst =
-  let rec aux part lst =
-    match lst with
-    | [] -> [List.map List.rev part]
-    | e::lst ->
-      let parts = part |> map_among_others' (fun left s right -> List.rev_append left ((e::s) :: right)) in
-      parts |> List.concat_map (fun part -> aux part lst)
-  in
-  aux (List.init n (fun _ -> [])) lst
-
 (*
   fold_distribute_comb f comb acc [x1;x2;...;xn] [y1;y2;...;yn]
   computes
@@ -115,43 +87,23 @@ let filter_among_others pred =
 let map_among_others f =
   fold_acc_rem (fun c acc rem -> (f c (acc@rem))::acc)
 
-let find_map_among_others f lst =
-  let rec loop acc = function
-    | [] -> None
-    | e :: l -> 
-      match f e (List.rev_append acc l) with
-        None ->  loop (e::acc) l
-      | o -> o
-  in loop [] lst
-
-let find_among_others pred lst =
-  find_map_among_others (fun e l  -> if pred e l then Some (e, l) else None) lst
-
 let merge_when_possible merge_opt lst =
-  let merge_opt a b others =
-    merge_opt a b |> Option.map (fun a -> (a, others))
+  let rec find_map_in_tail acc e l =
+    match l with
+    | [] -> None
+    | e' :: l -> match merge_opt e e' with
+        None -> find_map_in_tail (e' :: acc) e l
+      | Some a -> Some (a :: List.rev_append acc l)
   in
   let rec aux lst =
     match lst with
-    | [] -> []
-    | e::lst ->
-      begin match find_map_among_others (fun e' lst -> merge_opt e e' lst) lst with
-        | None -> e::(aux lst)
-        | Some (e, lst) -> aux (e::lst)
-      end
-  in
-  aux lst
+      [] -> []
+    | e :: lst -> match find_map_in_tail [] e lst with
+        None -> e :: aux lst
+      | Some l -> aux l
+  in aux lst
 
-let find_opt_of_iter (type a) (f : a -> bool) it col =
-  let exception Found of a in
-  try it (fun e -> if f e then raise_notrace (Found e)) col; None with
-  | Found e -> Some e
-
-let find_opt_of_iter2 (type a b) (f : a -> b -> bool) it col =
-  let exception Found of (a*b) in
-  try it (fun x y -> if f x y then raise_notrace (Found (x,y))) col; None with
-  | Found e -> Some e
-
+(* Base case of set-theoretic operations. *)
 let[@inline always] fcup ~empty ~any ~cup t1 t2 =
   if t1 == any || t1 == t2 || t2 == empty then t1
   else if t2 == any || t1 == empty then t2

--- a/src/lib/utils/sstt_utils.ml
+++ b/src/lib/utils/sstt_utils.ml
@@ -80,28 +80,27 @@ let partitions n lst =
   aux (List.init n (fun _ -> [])) lst
 
 (*
-  forall_distribute_comb f comb [x1;x2;...;xn] [y1;y2;...;yn]
+  fold_distribute_comb f comb acc [x1;x2;...;xn] [y1;y2;...;yn]
   computes
-  f [comb x1 y1; x2; ...; xn] &&
-  f [x1; comb x2 y2; ...; xn] &&
+  let acc = f acc [comb x1 y1; x2; ...; xn] in
+  let acc = f acc [x1; comb x2 y2; ...; xn] in
   ...
-  f [x1;x2; ....; comb xn yn] 
+  let acc = f [x1;x2; ....; comb xn yn] in
+  acc
 
 *)
-let forall_distribute_comb f comb ss tt =
-  let rec loop acc ss tt =
+
+let fold_distribute_comb f comb accv ss tt  =
+  let rec loop accl ss tt accv =
     match ss, tt with
-    | [], [] -> true
+    | [], [] -> accv
     | s::ss, t::tt ->
-      begin match comb s t with
-          None -> loop (s :: acc) ss tt
-        | Some c -> let line = List.rev_append acc (c::ss) in
-          f line && loop (s::acc) ss tt
-      end
+      let line = List.rev_append accl ((comb s t)::ss) in
+      let accv' = f accv line in
+      loop (s::accl) ss tt accv'
     | _ -> failwith "forall_distribute_comb: invalid list length"
   in
-  loop [] ss tt
-
+  loop [] ss tt accv
 let fold_acc_rem f lst =
   let rec aux acc rem =
     match rem with


### PR DESCRIPTION
This small PR does two things:
- some various optimizations, whose main goal is mainly to avoid some allocations/list traversals/or try harder to maintain physical equality when a data-structure remains unchanged after a traversal
- refactor the code for the sub-typing of arrows/records/tuples and the corresponding code for normalization of constraints in the tallying procedure. The code for converting records to tuples is exposed (so that it can be called from the tallying instead of duplicated). The code for generating constraints is shared between tuples and records. The three (arrows, records, tuples) constraint generating code for the tallying now follow closely the corresponding emptiness test based on `psi`.