### PR TITLE
Generalize the Tag component

### DIFF
--- a/src/lib/repl/parsing/ast.mli
+++ b/src/lib/repl/parsing/ast.mli
@@ -2,14 +2,14 @@ open Sstt
 
 type builtin =
   | TEmpty | TAny | TAnyTuple | TAnyEnum | TAnyTag | TAnyInt
-  | TAnyArrow | TAnyRecord | TAnyTupleComp of int | TAnyTagComp of Tag.t
+  | TAnyArrow | TAnyRecord | TAnyTupleComp of int
 type varop = TTuple
 type binop = TCap | TCup | TDiff | TArrow
 type unop = TNeg
 type ty =
   | TBuiltin of builtin
   | TNamed of string
-  | TTag of string * ty
+  | TTag of string * ty option
   | TVar of string
   | TVarMono of string
   | TInterval of Z.t option * Z.t option

--- a/src/lib/repl/parsing/parser.mly
+++ b/src/lib/repl/parsing/parser.mly
@@ -109,8 +109,8 @@ simple_ty:
 
 atomic_ty:
 | id=ID { parse_atom_or_builtin id }
-| id=TAGID ty=ty RPAREN { TTag (id, ty) }
-| id=TAGID RPAREN { TTag (id, TBuiltin (TAnyTupleComp 0)) }
+| id=TAGID ty=ty RPAREN { TTag (id, Some ty) }
+| id=TAGID RPAREN { TTag (id, None) }
 | id=VARID { TVar id }
 | id=MVARID { TVarMono id }
 | i=INT { TInterval (Some i, Some i) }

--- a/src/lib/sstt/core/base.ml
+++ b/src/lib/sstt/core/base.ml
@@ -13,13 +13,38 @@ module LabelMap = Map.Make(Label)
 
 
 (** @canonical Sstt.Tag *)
-module Tag = Id.NamedIdentifier()
-(** Tags used for tagged type. *)
+module Tag : sig
+  include Id.NamedIdentifier
+  type prop =
+  | NoProperty
+  | Monotonic of { preserves_cup:bool ; preserves_cap:bool }
+
+  val mk' : string -> prop -> t
+  val properties : t -> prop
+end = struct
+  module I = Id.NamedIdentifier()
+  type prop =
+  | NoProperty
+  | Monotonic of { preserves_cup:bool ; preserves_cap:bool }
+
+  type t = I.t * prop
+  let default_prop = Monotonic { preserves_cap=true ; preserves_cup=true }
+  let mk name =  (I.mk name, default_prop)
+  let mk' name prop =  (I.mk name, prop)
+  let name (i,_) = I.name i
+  let properties (_,p) = p
+  let hash (i,_) = I.hash i
+  let compare (i1,_) (i2,_) = I.compare i1 i2
+  let equal (i1,_) (i2,_) = I.equal i1 i2
+  let pp fmt (i,_) = Format.fprintf fmt "%a" I.pp i
+  let pp_unique fmt (i,_) = Format.fprintf fmt "%a" I.pp i
+end
+(** Identifiers used for tagged type. *)
 
 
 (** @canonical Sstt.Enum *)
 module Enum = Id.NamedIdentifier()
-(** Identifiers used for enums. *)
+(** Identifiers used for enums type. *)
 
 
 (** @canonical Sstt.Var *)

--- a/src/lib/sstt/core/sigs.ml
+++ b/src/lib/sstt/core/sigs.ml
@@ -639,8 +639,11 @@ module type TagComp = sig
   val tag : t -> Tag.t
   (** [tag t] returns the common tag of all the tagged-types in this component. *)
 
-  val as_atom : t -> Atom.t
-  (** [as_atom t] returns [t] as a pair of its tag and a plain type. *)
+  val line_emptiness_checks : Tag.t -> (Atom.t list * Atom.t list) -> node list
+  (** [line_emptiness_checks tag (ps, ns)] converts a line of a [TagComp] DNF of tag [tag] to
+      a list of types [tys] such that emptiness of the DNF line is equivalent to
+      emptiness of at least one of the [tys].
+  *)
 end
 
 module type Tags = sig

--- a/src/lib/sstt/core/sigs.ml
+++ b/src/lib/sstt/core/sigs.ml
@@ -639,10 +639,10 @@ module type TagComp = sig
   val tag : t -> Tag.t
   (** [tag t] returns the common tag of all the tagged-types in this component. *)
 
-  val line_emptiness_checks : Tag.t -> (Atom.t list * Atom.t list) -> node list
-  (** [line_emptiness_checks tag (ps, ns)] converts a line of a [TagComp] DNF of tag [tag] to
+  val line_emptiness_checks : (node -> 'a) -> Tag.t -> (Atom.t list * Atom.t list) -> 'a list
+  (** [line_emptiness_checks f tag (ps, ns)] converts a line of a [TagComp] DNF of tag [tag] to
       a list of types [tys] such that emptiness of the DNF line is equivalent to
-      emptiness of at least one of the [tys].
+      emptiness of at least one of the [tys]. The function [f] is called on each [tys].
   *)
 end
 

--- a/src/lib/sstt/types/extensions/abstracts.ml
+++ b/src/lib/sstt/types/extensions/abstracts.ml
@@ -101,7 +101,7 @@ let extract_params vs ty =
   if Ty.equiv ty ty' then res else invalid_arg "Malformed abstract type"
 
 let proj_tag tag ty = ty |> Ty.get_descr |> Descr.get_tags |> Tags.get tag
-                      |> TagComp.as_atom |> snd
+                      |> Op.TagComp.as_atom |> snd
 
 let destruct_p tag pty =
   check_abstract tag;
@@ -112,7 +112,7 @@ let destruct tag ty =
 
 let to_t node ctx comp =
   try
-    let (tag, pty) = TagComp.as_atom comp in
+    let (tag, pty) = Op.TagComp.as_atom comp in
     let params = destruct_p tag pty in
     let map_node l = List.map (node ctx) l in
     List.map (fun (p1, p2) ->

--- a/src/lib/sstt/types/extensions/abstracts.ml
+++ b/src/lib/sstt/types/extensions/abstracts.ml
@@ -1,16 +1,24 @@
 open Core
 open Sstt_utils
 
-type variance = Cov | Contrav | Inv
 type 't params = 't list
 type 't t = ('t params list * 't params list) list
 
-let atypes = Hashtbl.create 256
-let is_abstract tag = Hashtbl.mem atypes tag
+module THT = Hashtbl.Make(Tag)
+let abs_tags = THT.create 10
+
+let is_abstract tag = THT.mem abs_tags tag
 let check_abstract tag =
-  if not (is_abstract tag) then
+  if is_abstract tag |> not then
     invalid_arg 
-      (Format.asprintf "Unregistered abstract type '%a'" Tag.pp tag)
+      (Format.asprintf "Undefined abstract type '%a'" Tag.pp tag)
+let arity tag =
+  check_abstract tag ; THT.find abs_tags tag
+
+let define name n =
+  let abs = Tag.mk' name Tag.NoProperty in
+  THT.add abs_tags abs n ; abs
+
 let labels = Hashtbl.create 10
 let label_of_position i =
   match Hashtbl.find_opt labels i with
@@ -19,101 +27,62 @@ let label_of_position i =
     let lbl = Label.mk (string_of_int i) in
     Hashtbl.add labels i lbl ; lbl
 
-let define name (vs:variance list) =
-  let tag = Tag.mk name in
-  Hashtbl.add atypes tag vs ;
-  tag
-
-let encode_params vs ps =
-  let (ls, rs) =
-    List.combine vs ps |> List.mapi (fun i (v,p) ->
-        let lbl = label_of_position i in
-        let constr = (lbl, Ty.O.optional p) in
-        let noconstr = (lbl, Ty.O.any) in
-        match v with
-        | Cov -> noconstr, constr
-        | Contrav -> constr, noconstr
-        | Inv -> constr, constr
-      ) |> List.split
+let encode_params ps =
+  let bindings = ps |> List.mapi (fun i p ->
+      (label_of_position i, Ty.O.optional p)
+    ) |> LabelMap.of_list
   in
-  let mk_record bs =
-    let open Records.Atom in
-    { bindings = bs |> LabelMap.of_list ; opened = true }
-    |> Descr.mk_record |> Ty.mk_descr
-  in
-  let lhs, rhs = mk_record ls, mk_record rs in
-  Descr.mk_arrow (lhs,rhs) |> Ty.mk_descr
+  { Records.Atom.bindings ; Records.Atom.opened=false }
+  |> Descr.mk_record |> Ty.mk_descr
 
 let mk tag ps =
-  check_abstract tag;
-  let vs = Hashtbl.find atypes tag in
-  let ty = encode_params vs ps in
-  (tag, ty) |> Descr.mk_tag |> Ty.mk_descr
+  let n = arity tag in
+  if List.length ps <> n then
+    invalid_arg (Format.asprintf "Wrong arity for '%a'" Tag.pp tag) ;
+  (tag, encode_params ps) |> Descr.mk_tag |> Ty.mk_descr
 
-let mk_any tag = (tag, Ty.any) |> Descr.mk_tag |> Ty.mk_descr
+let mk_any tag =
+  check_abstract tag ;
+  TagComp.any tag |> Descr.mk_tagcomp |> Ty.mk_descr
 
-let is_abstract tag = Hashtbl.mem atypes tag
-let params_of tag =
-  check_abstract tag;
-  Hashtbl.find atypes tag
-let extract_params vs ty =
-  let n = List.length vs in
-  let convert_to_tuple r =
-    let open Records.Atom in
-    List.init n (fun i -> find (label_of_position i) r |> fst)
+let extract_dnf tag dnf =
+  let open Records.Atom in
+  let n = arity tag in
+  let extract_param record i =
+    find (label_of_position i) record |> Ty.O.get
   in
-  let extract_tuples ty =
-    Ty.get_descr ty |> Descr.get_records |> Op.Records.as_union |>
-    List.map convert_to_tuple
+  let extract_params record =
+    List.init n Fun.id |> List.map (extract_param record)
   in
-  let extract_tuple ty =
-    Ty.get_descr ty |> Descr.get_records |> Op.Records.approx |>
-    convert_to_tuple
+  let extract_params (_, ty) =
+    Ty.get_descr ty |> Descr.get_records
+    |> Op.Records.approx |> extract_params
   in
-  let aux (ls, rs) =
-    let aux (v,(l,r)) =
-      match v with
-      | Cov -> r
-      | Contrav -> l
-      | Inv -> l
-    in
-    let tys = List.combine ls rs in
-    List.combine vs tys |> List.map aux
-  in
-  let aux (l, r) =
-    let uls, rs = extract_tuples l, extract_tuple r in
-    uls |> List.map (fun ls -> (ls,rs)) |> List.map aux
-  in
-  let res = Ty.get_descr ty |> Descr.get_arrows |> Arrows.dnf
-            |> List.map (fun (ps, ns) ->
-                List.concat_map aux ps,
-                List.concat_map aux ns
-              ) in
+  let res = dnf |> List.map (fun (ps, ns) ->
+    (List.map extract_params ps, List.map extract_params ns)
+  ) in
   (* We check that the encoding of the result is equivalent to the initial type [ty]
      (otherwise it means that [ty] is not a valid encoding of an abstract type) *)
+  let build_from_dnf dnf =
+    TagComp.of_dnf tag dnf |> Descr.mk_tagcomp |> Ty.mk_descr
+  in
+  let ty = build_from_dnf dnf in
   let ty' =
     res |> List.map (fun (ps, ns) ->
-        let ps = ps |> List.map (encode_params vs) |> Ty.conj in
-        let ns = ns |> List.map (encode_params vs) |> List.map Ty.neg |> Ty.conj in
-        Ty.cap ps ns
-      ) |> Ty.disj
+        (ps |> List.map (fun ty -> tag, encode_params ty),
+         ns |> List.map (fun ty -> tag, encode_params ty))
+      ) |> build_from_dnf
   in
   if Ty.equiv ty ty' then res else invalid_arg "Malformed abstract type"
 
-let proj_tag tag ty = ty |> Ty.get_descr |> Descr.get_tags |> Tags.get tag
-                      |> Op.TagComp.as_atom |> snd
-
-let destruct_p tag pty =
-  check_abstract tag;
-  let vs = Hashtbl.find atypes tag in
-  extract_params vs pty
 let destruct tag ty =
-  proj_tag tag ty |> destruct_p tag
+  ty |> Ty.get_descr |> Descr.get_tags |> Tags.get tag
+  |> TagComp.dnf |> extract_dnf tag
 
 let to_t node ctx comp =
   try
-    let (tag, pty) = Op.TagComp.as_atom comp in
-    let params = destruct_p tag pty in
+    let tag, dnf = TagComp.tag comp, TagComp.dnf comp in
+    let params = extract_dnf tag dnf in
     let map_node l = List.map (node ctx) l in
     List.map (fun (p1, p2) ->
         List.map map_node p1, List.map map_node p2

--- a/src/lib/sstt/types/extensions/abstracts.mli
+++ b/src/lib/sstt/types/extensions/abstracts.mli
@@ -1,12 +1,11 @@
 open Core
 
-type variance = Cov | Contrav | Inv
 type 't params = 't list
 type 't t = ('t params list * 't params list) list
 
-val define : string -> variance list -> Tag.t
+val define : string -> int -> Tag.t
 val is_abstract : Tag.t -> bool
-val params_of : Tag.t -> variance list
+val arity : Tag.t -> int
 val mk : Tag.t -> Ty.t list -> Ty.t
 val mk_any : Tag.t -> Ty.t
 val destruct : Tag.t -> Ty.t -> Ty.t t

--- a/src/lib/sstt/types/extensions/bools.ml
+++ b/src/lib/sstt/types/extensions/bools.ml
@@ -26,7 +26,7 @@ let components { t ; f } =
   ] |> List.filter_map (fun (b,k) -> if b then Some k else None)
 
 let to_t _ _ comp =
-  let (_, pty) = TagComp.as_atom comp in
+  let (_, pty) = Op.TagComp.as_atom comp in
   if Ty.leq pty any_p && (Ty.vars_toplevel pty |> VarSet.is_empty)
   then
     let t = Ty.leq tt_p pty in

--- a/src/lib/sstt/types/extensions/chars.ml
+++ b/src/lib/sstt/types/extensions/chars.ml
@@ -24,7 +24,7 @@ let any = add_tag any_p
 type t = interval list
 
 let to_t _ _ comp =
-  let (_, pty) = TagComp.as_atom comp in
+  let (_, pty) = Op.TagComp.as_atom comp in
   if Ty.leq pty any_p && Ty.vars_toplevel pty |> VarSet.is_empty
   then
     Some (pty |> Ty.get_descr |> Descr.get_intervals |> Intervals.destruct

--- a/src/lib/sstt/types/extensions/floats.ml
+++ b/src/lib/sstt/types/extensions/floats.ml
@@ -54,7 +54,7 @@ let components { ninf ; neg ; nzero ; pzero ; pos ; pinf ; nan } =
   ] |> List.filter_map (fun (b,k) -> if b then Some k else None)
 
 let to_t _ _ comp =
-  let (_, pty) = TagComp.as_atom comp in
+  let (_, pty) = Op.TagComp.as_atom comp in
   let (pos, enums') = pty |> Ty.get_descr |> Descr.get_enums |> Enums.destruct in
   if pos && Ty.leq pty any_p && (Ty.vars_toplevel pty |> VarSet.is_empty) then
     let has k =

--- a/src/lib/sstt/types/extensions/hierarchy.ml
+++ b/src/lib/sstt/types/extensions/hierarchy.ml
@@ -51,7 +51,7 @@ and line = L of Node.t * t
 
 let any_enum = Enums.any |> Descr.mk_enums |> Ty.mk_descr
 let to_t h _ _ cmp =
-  let (_, pty) = TagComp.as_atom cmp in
+  let (_, pty) = Op.TagComp.as_atom cmp in
   if Ty.leq pty any_enum && (Ty.vars_toplevel pty |> VarSet.is_empty)
   then
     let (pos, enums) = pty |> Ty.get_descr |> Descr.get_enums |> Enums.destruct in

--- a/src/lib/sstt/types/extensions/lists/lists.ml
+++ b/src/lib/sstt/types/extensions/lists/lists.ml
@@ -6,7 +6,7 @@ let tag = Tag.mk "lst"
 
 let add_tag ty = (tag, ty) |> Descr.mk_tag |> Ty.mk_descr
 let proj_tag ty = ty |> Ty.get_descr |> Descr.get_tags |> Tags.get tag
-                  |> TagComp.as_atom |> snd
+                  |> Op.TagComp.as_atom |> snd
 
 let cons hd tl = [hd;tl] |> Descr.mk_tuple |> Ty.mk_descr |> add_tag
 

--- a/src/lib/sstt/types/extensions/maps.ml
+++ b/src/lib/sstt/types/extensions/maps.ml
@@ -8,7 +8,7 @@ let tag = Tag.mk "map"
 
 let add_tag ty = (tag, ty) |> Descr.mk_tag |> Ty.mk_descr
 let proj_tag ty = ty |> Ty.get_descr |> Descr.get_tags |> Tags.get tag
-                  |> TagComp.as_atom |> snd
+                  |> Op.TagComp.as_atom |> snd
 
 let mk (ps, ns) =
   let ps = ps |> List.map (fun f -> f.dom, f.codom) in
@@ -41,7 +41,7 @@ let map f l =
 
 let to_t node ctx comp =
   try
-    let (_, pty) = TagComp.as_atom comp in
+    let (_, pty) = Op.TagComp.as_atom comp in
     if Ty.leq pty any_p |> not then raise Exit ;
     let l = destruct_p pty in
     Some (map (node ctx) l)

--- a/src/lib/sstt/types/extensions/maps.ml
+++ b/src/lib/sstt/types/extensions/maps.ml
@@ -19,7 +19,7 @@ let mk' fields = mk (fields, [])
 let any = mk' []
 let any_p = proj_tag any
 
-let destruct_p pty =
+let extract_dnf pty =
   if Ty.vars_toplevel pty |> VarSet.is_empty then
     pty |> Ty.get_descr |> Descr.get_arrows |> Arrows.dnf
     |> List.map (fun (ps, ns) ->
@@ -33,7 +33,7 @@ let destruct_p pty =
   else
     invalid_arg "Malformed map type"
 
-let destruct ty = proj_tag ty |> destruct_p
+let destruct ty = proj_tag ty |> extract_dnf
 
 let map f l =
   let ff t = { dom = f t.dom; codom = f t.codom } in
@@ -43,7 +43,7 @@ let to_t node ctx comp =
   try
     let (_, pty) = Op.TagComp.as_atom comp in
     if Ty.leq pty any_p |> not then raise Exit ;
-    let l = destruct_p pty in
+    let l = extract_dnf pty in
     Some (map (node ctx) l)
   with _ -> None
 let proj ~dom t =

--- a/src/lib/sstt/types/extensions/strings.ml
+++ b/src/lib/sstt/types/extensions/strings.ml
@@ -23,7 +23,7 @@ let any = add_tag any_p
 type t = bool * string list
 
 let to_t _ _ comp =
-  let (_, pty) = TagComp.as_atom comp in
+  let (_, pty) = Op.TagComp.as_atom comp in
   if Ty.leq pty any_p && (Ty.vars_toplevel pty |> VarSet.is_empty) then
     let (pos, enums) = pty |> Ty.get_descr |> Descr.get_enums |> Enums.destruct in
     let strs = enums |> List.map Enum.name in

--- a/src/lib/sstt/types/op.ml
+++ b/src/lib/sstt/types/op.ml
@@ -104,3 +104,24 @@ module Records = struct
     { a with bindings } |> Records.mk
 
 end
+
+module TagComp = struct
+  type t = TagComp.t
+  type atom = TagComp.Atom.t
+
+  let is_identity t =
+    let p = TagComp.tag t |> Tag.properties in
+    match p with
+    | Tag.NoProperty -> false
+    | Tag.Monotonic m -> m.preserves_cap && m.preserves_cup
+
+  let as_atom t =
+    if is_identity t |> not then
+      invalid_arg "Tag component must satisfy is_identity." ;
+    let ty_of_clause (ps,ns) =
+      let p = ps |> List.map snd |> Ty.conj in
+      let n = ns |> List.map snd |> List.map Ty.neg |> Ty.conj in
+      Ty.cap p n
+    in
+    TagComp.tag t, TagComp.dnf t |> List.map ty_of_clause |> Ty.disj
+end

--- a/src/lib/sstt/types/op.mli
+++ b/src/lib/sstt/types/op.mli
@@ -88,3 +88,19 @@ module Records : sig
       absent in [t]. *)
   val remove : atom -> Label.t -> t
 end
+
+module TagComp : sig
+  (** Operations on tag types. *)
+
+  type t = TagComp.t
+  type atom = TagComp.Atom.t
+
+(** [is_identity t] returns [true] if and only if the component [t]
+    is a tag component whose underlying interpretation is isomorphic
+    to the identity, that is, if it is monotonic and {m \cap}-{m \cup}-preserving. *)
+  val is_identity : t -> bool
+
+  (** [as_atom t] expresses [t] as an atom.
+      Raises: [Invalid_argument] if the tag component does not satisfy [is_identity]. *)
+  val as_atom : t -> atom
+end

--- a/src/lib/sstt/types/printer/printer.mli
+++ b/src/lib/sstt/types/printer/printer.mli
@@ -15,7 +15,7 @@ end
 
 type builtin =
   | Empty | Any | AnyTuple | AnyEnum | AnyTag | AnyInt
-  | AnyArrow | AnyRecord | AnyTupleComp of int
+  | AnyArrow | AnyRecord | AnyTupleComp of int | AnyTagComp of Tag.t
 type t = { main : descr ; defs : def list }
 and def = NodeId.t * descr
 and descr = { op : op ; ty : Ty.t }

--- a/src/lib/sstt/types/tallying.ml
+++ b/src/lib/sstt/types/tallying.ml
@@ -237,8 +237,10 @@ module Make(VO:VarOrder) = struct
     and norm_tags tag =
       let (cs, others) = tag |> Tags.components in
       if others then CSS.empty
-      else cs |>
-           CSS.map_conj delta (fun c -> TagComp.as_atom c |> snd |> norm_ty)
+      else cs |> CSS.map_conj delta norm_tagcomp
+    and norm_tagcomp c =
+      let tag = TagComp.tag c in
+      c |> TagComp.dnf |> CSS.map_conj delta (norm_tag tag)      
     and norm_arrows arr =
       arr |> Arrows.dnf |> CSS.map_conj delta norm_arrow
     and norm_tuples tup =
@@ -275,6 +277,8 @@ module Make(VO:VarOrder) = struct
       List.map (norm_single_neg_arrow ps) ns |> CSS.disj
     and norm_tuple n line = norm_tuple_gen ~any:Ty.any ~conj:Ty.conj
         ~diff:Ty.diff ~norm:norm_ty delta n line
+    and norm_tag tag line =
+      TagComp.line_emptiness_checks tag line |> List.map norm_ty |> CSS.disj
     and norm_record (ps, ns) =
       let line, n = Records.dnf_line_to_tuple (ps, ns) in
       norm_tuple_gen ~any:Ty.O.any ~conj:Ty.O.conj

--- a/src/lib/sstt/types/tallying.ml
+++ b/src/lib/sstt/types/tallying.ml
@@ -278,7 +278,7 @@ module Make(VO:VarOrder) = struct
     and norm_tuple n line = norm_tuple_gen ~any:Ty.any ~conj:Ty.conj
         ~diff:Ty.diff ~norm:norm_ty delta n line
     and norm_tag tag line =
-      TagComp.line_emptiness_checks tag line |> List.map norm_ty |> CSS.disj
+      TagComp.line_emptiness_checks norm_ty tag line |> CSS.disj
     and norm_record (ps, ns) =
       let line, n = Records.dnf_line_to_tuple (ps, ns) in
       norm_tuple_gen ~any:Ty.O.any ~conj:Ty.O.conj

--- a/src/lib/sstt/types/transform.ml
+++ b/src/lib/sstt/types/transform.ml
@@ -106,7 +106,12 @@ let simpl_tuples p =
   TupleComp.dnf p |> List.map regroup_tuples
   |> merge_when_possible merge_tuple_lines |> TupleComp.of_dnf n
 let simpl_tuples t = Tuples.map simpl_tuples t
-let simpl_tags t = Tags.map (fun c -> TagComp.as_atom c |> TagComp.mk) t
+let simpl_tags t = Tags.map (fun c ->
+    if Op.TagComp.is_identity c then
+      Op.TagComp.as_atom c |> TagComp.mk
+    else
+      c
+  ) t
 
 let simpl_descr d =
   let open Descr in

--- a/src/lib/utils/sstt_utils.ml
+++ b/src/lib/utils/sstt_utils.ml
@@ -57,7 +57,7 @@ let mapn default f lst =
   let acc = f acc [comb x1 y1; x2; ...; xn] in
   let acc = f acc [x1; comb x2 y2; ...; xn] in
   ...
-  let acc = f [x1;x2; ....; comb xn yn] in
+  let acc = f acc [x1;x2; ....; comb xn yn] in
   acc
 
 *)

--- a/src/tests/tests.ml
+++ b/src/tests/tests.ml
@@ -189,7 +189,7 @@ let%expect_test "tests_ext" =
     let fn = "tests_ext.txt" in
     let cin = open_in fn in
     let buf = Lexing.from_channel cin in
-    let abs_tag = Abstracts.define "abs" [Inv] in
+    let abs_tag = Abstracts.define "abs" 1 in
     let abs_printer = Abstracts.printer_params abs_tag in
     let pparams = [
       Lists.printer_params ; Bools.printer_params ; Chars.printer_params ;

--- a/src/tests/tests.ml
+++ b/src/tests/tests.ml
@@ -21,7 +21,7 @@ let%expect_test "tests" =
     empty2: true
     atom1: false
     atom2: true
-    tags1: tag((false, true) | (true, false))
+    tags1: tag(false, true) | tag(true, false)
     tags2: tag1(true, false) | tag2(false, true)
     tags3: true
     tags4: 42

--- a/src/tests/tests.txt
+++ b/src/tests/tests.txt
@@ -79,7 +79,7 @@ type unit = () ;;
 "print16" ~(40..44) ;;
 "print17" ~tag(42) ;;
 "print18" ('a->'b)&('c->'d)&~('e->'f)&~('g->'h) ;;
-"print19" tag\sometag() ;;
+"print19" tag\sometag(unit) ;;
 "print20" ~(int|bool|unit) ;;
 
 "tally1" [ 'x <= 'y ] ;;

--- a/src/tests/tests_ext.txt
+++ b/src/tests/tests_ext.txt
@@ -33,5 +33,5 @@ type ba = lst(43,lst(42,list));;
 "char_invalid" chr(something) ;;
 "map_invalid" map(empty -> any) ;;
 
-"abs_any" abs(any) ;;
+"abs_any" abs() ;;
 "abs_invalid" abs(42) ;;

--- a/src/tests/tests_ext.txt
+++ b/src/tests/tests_ext.txt
@@ -1,10 +1,10 @@
 
-type list = x where x = lst() | lst(any,x) ;;
+type list = x where x = lst(()) | lst(any,x) ;;
 type fst42 = lst(42, list) ;;
 type snd43 = lst(any, lst(43,list)) ;;
 "list_42_43" fst42 & snd43 ;;
 
-type list_a = x where x = lst() | lst('a,x) ;;
+type list_a = x where x = lst(()) | lst('a,x) ;;
 "int_list" list_a ['a : int] ;;
 "list_not_only_a" list & ~list_a ;;
 


### PR DESCRIPTION
The Tag component is generalized to allow an arbitrary interpretation. Properties such as monotonicity and preservation of cap and cup can be specified, and subtyping is computed accordingly. When not specified, the default properties of a tag are "monotonic + preserves cap and cup", which amounts to an identity interpretation, equivalent to the former definition of Tags.
The default handling of Tags in the Printer has been generalized: now it shows the DNF (like for arrows).

Breaking changes:
- TagComp.as_atom moved into Op.TagComp.as_atom. Now requires the tag to have an identity interpretation (Op.TagComp.is_identity).

NOTE: I have not updated yet the Abstracts extension (it still uses the old encoding).
But it has no impact on the rest so it can wait.