### PR TITLE
Fix the backtraking table and make the code more robust.

### DIFF
--- a/src/lib/sstt/core/node.ml
+++ b/src/lib/sstt/core/node.ml
@@ -47,7 +47,7 @@ open Sigs
 
 
 include (struct
-  module rec TyRef : sig 
+  module rec TyRef : sig
     (* The type of type reference, this module only contains the type definition to avoid
        repeating it everywhere. *)
 
@@ -89,7 +89,7 @@ include (struct
     let equal t1 t2 = Int.equal t1.id t2.id
     let empty = mk ()
     let any = mk ()
-    
+
     let init empty_def any_def =
       assert (empty.def = None && any.def = None);
       empty.def <- Some empty_def;
@@ -112,7 +112,7 @@ include (struct
     let equal = AnyEmpty.equal
 
     let any = AnyEmpty.any
-    let empty = AnyEmpty.empty  
+    let empty = AnyEmpty.empty
   end
   and NSet : Set.S with type elt = AnyEmpty.t = Set.Make(PreNode) (* Sets of Node.t, but use PreNode to have a well defined cycle *)
   and VDescr : VDescr' with type node = Node.t = Vdescr.Make(Node) (* Instanciate VDescr *)
@@ -120,7 +120,7 @@ include (struct
                          and type row = VDescr.Descr.Records.Atom.t = struct
     (* The PreNode module that contain the entry points of all functions on types. *)
     module NH = Hashtbl.Make(PreNode)
-    module Table = Bttable.Make(VDescr)(Bool)
+    module Table = Bttable.MakeOpt(VDescr)(Bool)
     type _ Effect.t += GetCache: (Table.t) t
 
     type vdescr = VDescr.t

--- a/src/lib/sstt/core/utils/bttable.ml
+++ b/src/lib/sstt/core/utils/bttable.ml
@@ -7,29 +7,27 @@ module MakeOpt(V : Hashtbl.HashedType)(R : sig type t val equal : t -> t-> bool 
 
       This table can be used for computations over co-inductive structures whose
       results depend on an initial guess. When exploring a co-inductive value
-       [v : V.t], we say that [v] is [Active], if it is being explored and the
-      exploration is not finished or, if the exploration is finished but the computation
-      depended one or several [Active] values. The API is as follows:
+      [v : V.t], we first fix its result to an initial guess before exploring it.
+      If we find it again, return the initial guess. When coming back after exploration,
+      if the result is consistent with the initial guess we can simply return it.
+      If not, we need to invalidate all results stored in the table that depended
+      (directly or indirectly) on the initial guess.
+      This fits nicely with a look-up table pattern :
 
      - first, one looks for [v] in the table, using [find ~default:r table v]
      - if [v] is not in the table, it associates an initial result [r : R.t],
-          returns [None] and [v] becomes [Active]. The exploration of [v] can continue.
-     - if [v] is in the table, it means it is encountered again. The initial
-          value stored is returned as [Some r] and all values that became
-          active after [v] and are still active are recorded. These are the dependencies of [v].
+          The exploration of [v] can continue.
+     - if [v] is in the table, it means it is encountered again. The
+          value stored is returned as [Some r] and all values that are curently being
+          explored become [v]'s direct dependencies, which we record.
 
      - when returning from the initial exploration of [v] with a computed
        result [r'], one needs to update the result [update table v r']:
-     - if [R.equal r r'] then the initial guess was correct, we can mark the node
-          as [Inactive], its computation is finalized.
-     - otherwise:
-     - if [v] has no dependecy, then it's simply updated and also marked
-              as [Inactive]. It's result did not depend on any assumption that was wrong.
-     - otherwise the dependencies of [v] are removed from the table: they
-              were computed while making the (wrong) hypothesis that the result for
-              [v] was [r], while it is [r']. Later calls to [find ~default:r table v]
-              will return [r'] unless it is itself invalidated. In that case we must left
-              [v] as [Active].
+     - if [R.equal r r'] then the initial guess was correct the table is in a consistent state.
+     - otherwise the transitive dependencies of [v] are removed from the table: they
+          were computed while making the (wrong) hypothesis that the result for
+          [v] was [r], while it is [r']. Later calls to [find ~default:r table v]
+       will return [r'] unless it is itself invalidated.
 
       {@ocaml[ let rec explore table v =
 
@@ -76,7 +74,6 @@ end = struct
       Cons of { key : V.t; mutable marked : bool ; next : stack }
     | Nil
   type entry = {
-    mutable active : bool;             (* status of the entry *)
     mutable dependencies :stack list;  (* the top of the stack at the time the entry was accessed *)
     mutable result : R.t option;       (* the result stored in this entry *)
   }
@@ -91,15 +88,13 @@ end = struct
     match H.find_opt t.table key with
     | None ->
       (* The key is not in the table start from scratch *)
-      let entry = { active = true; dependencies = []; result = Some default } in
+      let entry = { dependencies = []; result = Some default } in
       t.stack <- Cons { key; marked = false; next = t.stack };
       H.add t.table key entry;
       None
 
     | Some entry ->
-      (* We find an entry, if it is active, record the dependencies, that is
-         the current stack. *)
-      if entry.active then entry.dependencies <- t.stack::entry.dependencies;
+      entry.dependencies <- t.stack::entry.dependencies;
       entry.result
 
   (* remove from the list until we find ourselves, this is when we where put
@@ -118,14 +113,12 @@ end = struct
     | _ -> ()
   let[@warning "-27"] update ?(naive=false) t key r =
     match H.find_opt t.table key, t.stack  with
-    | Some ({ active = true; result = Some old_r; _ } as cp), Cons s ->
+    | Some ({ result = Some old_r; _ } as cp), Cons s ->
       if not (R.equal r old_r) then begin
         cp.result <- Some r;
-        match cp.dependencies with
-          [] -> cp.active <- false
-        | deps -> List.iter (invalidate t.table t.stack) deps;
-      end else cp.active <- false;
-      t.stack <- s.next;
+        List.iter (invalidate t.table t.stack) cp.dependencies;
+      end;
+      t.stack <- s.next
     | _ -> raise InvalidAccess
 end
 module MakeSimple(V : Set.OrderedType)(R : sig type t val equal : t -> t-> bool end): sig

--- a/src/lib/sstt/core/utils/bttable.ml
+++ b/src/lib/sstt/core/utils/bttable.ml
@@ -1,31 +1,35 @@
-module Make(V : Hashtbl.HashedType)(R : sig type t val equal : t -> t-> bool end): sig
+exception InvalidAccess
+(** Raised if a entry is used more than once. *)
 
-  (** 
+module MakeOpt(V : Hashtbl.HashedType)(R : sig type t val equal : t -> t-> bool end): sig
+  (**
      Hash table specialized for computations over co-inductive structures.
 
       This table can be used for computations over co-inductive structures whose
       results depend on an initial guess. When exploring a co-inductive value
        [v : V.t], we say that [v] is [Active], if it is being explored and the
-      exploration is not finished. The API is as follows:
-     - first, one looks for [v] in the table, using [find ~default:r table v]
+      exploration is not finished or, if the exploration is finished but the computation
+      depended one or several [Active] values. The API is as follows:
 
+     - first, one looks for [v] in the table, using [find ~default:r table v]
      - if [v] is not in the table, it associates an initial result [r : R.t],
-            returns [None] and [v] becomes active. The exploration of
-            [v] can continue.
+          returns [None] and [v] becomes [Active]. The exploration of [v] can continue.
      - if [v] is in the table, it means it is encountered again. The initial
-            value stored is returned as [Some r] and all values that became
-            active after [v] and are still active are recorded. 
-            These are the dependencies of [v].
+          value stored is returned as [Some r] and all values that became
+          active after [v] and are still active are recorded. These are the dependencies of [v].
 
      - when returning from the initial exploration of [v] with a computed
-        result [r'], one needs to update the result [update table v r']:
-     - if [R.equal r r'] then the initial guess was correct, and all
-              dependencies are left as-is
-     - otherwise, the dependencies of [v] are removed from the table: they
+       result [r'], one needs to update the result [update table v r']:
+     - if [R.equal r r'] then the initial guess was correct, we can mark the node
+          as [Inactive], its computation is finalized.
+     - otherwise:
+     - if [v] has no dependecy, then it's simply updated and also marked
+              as [Inactive]. It's result did not depend on any assumption that was wrong.
+     - otherwise the dependencies of [v] are removed from the table: they
               were computed while making the (wrong) hypothesis that the result for
-              [v] was [r], while it is [r']. Later calls to [find ~default:r table
-              v] will return [r'] unless it is itself invalidated.
-
+              [v] was [r], while it is [r']. Later calls to [find ~default:r table v]
+              will return [r'] unless it is itself invalidated. In that case we must left
+              [v] as [Active].
 
       {@ocaml[ let rec explore table v =
 
@@ -44,9 +48,6 @@ module Make(V : Hashtbl.HashedType)(R : sig type t val equal : t -> t-> bool end
   type t
   (** The type of the table.*)
 
-  exception InvalidAccess
-  (** Raised if a entry is used more than once. *)
-
   val create : unit -> t
   (** Creates an empty table *)
 
@@ -59,7 +60,7 @@ module Make(V : Hashtbl.HashedType)(R : sig type t val equal : t -> t-> bool end
       is added and a entry is returned.
   *)
 
-  val update : t -> V.t -> R.t -> unit
+  val update : ?naive:bool -> t -> V.t -> R.t -> unit
   (** Updates the value associated with the value that created the entry.
         If the supplied value is not equal to the original one, all values in
         the table whose result dependend on the original result are removed from
@@ -72,7 +73,7 @@ end = struct
   module H = Hashtbl.Make(V)
 
   exception InvalidAccess
-  type stack = 
+  type stack =
       Cons of { key : V.t; mutable marked : bool ; next : stack }
     | Nil
   type entry = {
@@ -87,16 +88,16 @@ end = struct
   let create () = { table = H.create 0; stack = Nil}
   let clear t = H.clear t.table; t.stack <- Nil
 
-  let find ~default t key = 
+  let find ~default t key =
     match H.find_opt t.table key with
-    | None -> 
+    | None ->
       (* The key is not in the table start from scratch *)
       let entry = { active = true; dependencies = []; result = Some default } in
       t.stack <- Cons { key; marked = false; next = t.stack };
       H.add t.table key entry;
       None
 
-    | Some entry -> 
+    | Some entry ->
       (* We find an entry, if it is active, record the dependencies, that is
          the current stack. *)
       if entry.active then entry.dependencies <- t.stack::entry.dependencies;
@@ -104,22 +105,63 @@ end = struct
 
   (* remove from the list until we find ourselves, this is when we where put
      on the stack *)
-  let rec invalidate tbl stop deps = 
+  let rec invalidate tbl stop deps =
     match deps with
-    | Cons ({ key ; next ; marked }  as r) when not marked && not (V.equal key stop) ->
-      H.remove tbl key;
-      r.marked <- true;
-      invalidate tbl stop next
+    | Cons ({ key ; next ; marked }  as r) when deps != stop ->
+      if not marked then begin
+        r.marked <- true;
+        match H.find_opt tbl key with
+          None -> ()
+        | Some cp ->
+          H.remove tbl key; List.iter (invalidate tbl stop) cp.dependencies
+      end;
+      invalidate  tbl stop next
     | _ -> ()
-
-  let update t key r =
+  let[@warning "-27"] update ?(naive=false) t key r =
     match H.find_opt t.table key, t.stack  with
     | Some ({ active = true; result = Some old_r; _ } as cp), Cons s ->
       if not (R.equal r old_r) then begin
-        List.iter (invalidate t.table key) cp.dependencies;
         cp.result <- Some r;
-      end;
+        match cp.dependencies with
+          [] -> cp.active <- false
+        | deps -> List.iter (invalidate t.table t.stack) deps;
+      end else cp.active <- false;
       t.stack <- s.next;
-      cp.active <- false
     | _ -> raise InvalidAccess
+end
+module MakeSimple(V : Set.OrderedType)(R : sig type t val equal : t -> t-> bool end): sig
+  type t
+  val create : unit -> t
+  val clear : t -> unit
+  val find : default:R.t -> t -> V.t -> R.t option
+  val update : ?naive:bool -> t -> V.t -> R.t -> unit
+
+end = struct
+
+  module M = Map.Make(V)
+
+  type t = (R.t M.t list) ref
+
+  let create () = ref ([M.empty])
+  let clear r = r := [ M.empty ]
+  let find ~default t key =
+    let cache = match !t with [] -> assert false | c :: _ -> c in
+    match M.find_opt key cache with
+      Some _ as v -> v
+    | None ->
+      let new_cache = M.add key default cache in
+      t := new_cache :: !t;
+      None
+
+  let update ?(naive=false) t key r =
+    match !t with
+    | [] | [ _ ] -> raise InvalidAccess
+    | cache :: old_cache :: prev_stack ->
+      match M.find_opt key cache with
+      | None -> raise InvalidAccess
+      | Some old_r ->
+        let new_cache =
+          if R.equal r old_r && not naive then cache else M.add key r old_cache
+        in
+        t := (new_cache :: prev_stack)
 end

--- a/src/lib/sstt/core/utils/bttable.ml
+++ b/src/lib/sstt/core/utils/bttable.ml
@@ -72,18 +72,17 @@ module MakeOpt(V : Hashtbl.HashedType)(R : sig type t val equal : t -> t-> bool 
 end = struct
   module H = Hashtbl.Make(V)
 
-  exception InvalidAccess
   type stack =
       Cons of { key : V.t; mutable marked : bool ; next : stack }
     | Nil
   type entry = {
-    mutable active : bool;            (* status of the entry *)
+    mutable active : bool;             (* status of the entry *)
     mutable dependencies :stack list;  (* the top of the stack at the time the entry was accessed *)
-    mutable result : R.t option;      (* the result stored in this entry *)
+    mutable result : R.t option;       (* the result stored in this entry *)
   }
   and t = {
-    table :  entry H.t;                 (* The table of all entrys *)
-    mutable stack : stack;           (* The stack of entrys. *)
+    table :  entry H.t;                 (* The table of all entries *)
+    mutable stack : stack;              (* The stack of entries. *)
   }
   let create () = { table = H.create 0; stack = Nil}
   let clear t = H.clear t.table; t.stack <- Nil

--- a/src/lib/sstt/core/utils/bttable.ml
+++ b/src/lib/sstt/core/utils/bttable.ml
@@ -70,9 +70,7 @@ module MakeOpt(V : Hashtbl.HashedType)(R : sig type t val equal : t -> t-> bool 
 end = struct
   module H = Hashtbl.Make(V)
 
-  type stack =
-      Cons of { key : V.t; mutable marked : bool ; next : stack }
-    | Nil
+  type stack = V.t list
   type entry = {
     mutable dependencies :stack list;  (* the top of the stack at the time the entry was accessed *)
     mutable result : R.t option;       (* the result stored in this entry *)
@@ -81,15 +79,15 @@ end = struct
     table :  entry H.t;                 (* The table of all entries *)
     mutable stack : stack;              (* The stack of entries. *)
   }
-  let create () = { table = H.create 0; stack = Nil}
-  let clear t = H.clear t.table; t.stack <- Nil
+  let create () = { table = H.create 0; stack = []}
+  let clear t = H.clear t.table; t.stack <- []
 
   let find ~default t key =
     match H.find_opt t.table key with
     | None ->
       (* The key is not in the table start from scratch *)
       let entry = { dependencies = []; result = Some default } in
-      t.stack <- Cons { key; marked = false; next = t.stack };
+      t.stack <- key :: t.stack;
       H.add t.table key entry;
       None
 
@@ -101,10 +99,8 @@ end = struct
      on the stack *)
   let rec invalidate tbl stop deps =
     match deps with
-    | Cons ({ key ; next ; marked }  as r) when deps != stop ->
-      if not marked then begin
-        r.marked <- true;
-        match H.find_opt tbl key with
+    |  key :: next when deps != stop ->
+      begin  match H.find_opt tbl key with
           None -> ()
         | Some cp ->
           H.remove tbl key; List.iter (invalidate tbl stop) cp.dependencies
@@ -113,12 +109,12 @@ end = struct
     | _ -> ()
   let[@warning "-27"] update ?(naive=false) t key r =
     match H.find_opt t.table key, t.stack  with
-    | Some ({ result = Some old_r; _ } as cp), Cons s ->
+    | Some ({ result = Some old_r; _ } as cp), _ ::next ->
       if not (R.equal r old_r) then begin
         cp.result <- Some r;
         List.iter (invalidate t.table t.stack) cp.dependencies;
       end;
-      t.stack <- s.next
+      t.stack <- next
     | _ -> raise InvalidAccess
 end
 module MakeSimple(V : Set.OrderedType)(R : sig type t val equal : t -> t-> bool end): sig

--- a/src/tests/tests.ml
+++ b/src/tests/tests.ml
@@ -258,6 +258,7 @@ let%expect_test "tests" =
     perf5: [
              'X: 'x25 & 'X
            ]
+    hard_recursive1: true
     |}]
 
 open Extensions

--- a/src/tests/tests.txt
+++ b/src/tests/tests.txt
@@ -159,3 +159,25 @@ type disjoint_pairs =
 
 "perf4" ('x25, 25) <= disjoint_pairs ;;
 "perf5" [('X, 25) <= disjoint_pairs] ;;
+
+"hard_recursive1" x2 where
+   x1 = {
+        l1 : any -> any ;
+        l2 : (x2 -> x1) & ({ l1 : int -> int ..} -> any)
+   }
+   and
+   x2 = {
+        l1 : (any -> (x1, x1)) & (any -> (x2, x2)) ;
+        l2 : any -> any
+   }
+<=
+{
+    l1 : x2 ;
+    l2 : any -> any } | 'a_rational where
+   x1 = { l1 : any -> any ;
+          l2 : ({ l1 : x2 ; l2 : any -> any } -> x1) & ({ l1 : int -> int ..} -> any)
+        }
+   and
+   x2 = (any -> (x1, x1)) & (any -> ({ l1 : x2 ; l2 : any -> any },
+                                     { l1 : x2 ; l2 : any -> any }))
+;;


### PR DESCRIPTION
This fixes the problem where indirect dependencies of a node where not invalidated. Recall that we record the dependencies of a node only when it is an active node (i.e. its result is not final). The fix is twofold:

- first we only set a node to inactive when:
  1. Its result corresponds to the initial guess, or
  2. Its result differs, but it does not depend on active nodes

- when invalidating dependencies, we recursively invalidate the their dependencies.

This commit does the following:
  - fix the code of the optimized backtracking table implementation as explained above
  - update the documentation at the top of bttable to make the invalidation strategy more precise
  - add a default simpler imlpementation (essentially simulating the old map based approach)
  - the table's [update] function now take a [naive=false] default parameter
    - in the [MakeOpt] version of the functor (the one with dependency tracking), the parameter does nothing
    - in the [MakeSimple] version of the functor (the map based approach),
      - if [naive=true] the map simply behaves as a recursion handling map, all results used during the computation of a node are discarded
      - if [naive=false] (default) the map behaves like the previous map implementation, all results used during the computation are discarded only if the result for the current node does not coincide with the initial guess

   - adds the problematic recursive example to the test cases