### PR TITLE
Perform shallow hash-consing of cons/union/intersect/difference of no…

### DIFF
--- a/src/lib/sstt/core/components/fields.ml
+++ b/src/lib/sstt/core/components/fields.ml
@@ -38,23 +38,17 @@ module OTy(N:Node) = struct
   let disjoint (n1,b1) (n2,b2) = not (b1 && b2) && N.disjoint n1 n2
 
   let equal (n1,b1) (n2,b2) = b1 = b2 && N.equal n1 n2
-  let equal' f (n1,b1) (n2,b2) = b1 = b2 && f n1 n2
   let compare (n1,b1) (n2,b2) = Bool.compare b1 b2 |> ccmp N.compare n1 n2
-  let compare' f (n1,b1) (n2,b2) = Bool.compare b1 b2 |> ccmp f n1 n2
 
   let map_nodes f (n,b) = (f n, b)
   let direct_nodes (n,_) = [n]
   let simplify t = t
 
   let hash (n, b) = Hash.(mix (bool b) (N.hash n))
-  let hash' f (n, b) = Hash.(mix (bool b) (f n))
 end
 
 module Make(N:Node) = struct
   module OTy = OTy(N)
   include Polymorphic.Make(N)(RowVar)(OTy)
 
-  let equal' f = Bdd.equal' RowVar.equal (OTy.equal' f)
-  let compare' f = Bdd.compare' RowVar.compare (OTy.compare' f)
-  let hash' f = Bdd.hash' RowVar.hash (OTy.hash' f)
 end

--- a/src/lib/sstt/core/core.ml
+++ b/src/lib/sstt/core/core.ml
@@ -66,6 +66,7 @@ module Ty : Ty = struct
   let is_any t = N.with_own_cache N.is_any t
 
   let compare, equal, hash = N.compare, N.equal, N.hash
+  let reset_caches = N.reset_caches 
 end
 
 (** @canonical Sstt.VDescr *)

--- a/src/lib/sstt/core/core.ml
+++ b/src/lib/sstt/core/core.ml
@@ -19,7 +19,7 @@ open Sigs
      constructors and are union of intersections of atoms, the latter containing type references {!Ty.t}. For instance,
      the component for {{!Arrows} arrows} represents:
       {math
-      a = \bigcup_{i=1\ldots m} \bigcap_{j=1 \ldots p} t_{ij}^1 \rightarrow t_{ij}^2 \cap \bigcap_{j=1 \ldots n} \lnot(t_{ij}^1 \rightarrow t_{ij}^2) 
+      a = \bigcup_{i=1\ldots m} \bigcap_{j=1 \ldots p} t_{ij}^1 \rightarrow t_{ij}^2 \cap \bigcap_{j=1 \ldots n} \lnot(t_{ij}^1 \rightarrow t_{ij}^2)
       }
 *)
 
@@ -66,7 +66,6 @@ module Ty : Ty = struct
   let is_any t = N.with_own_cache N.is_any t
 
   let compare, equal, hash = N.compare, N.equal, N.hash
-  let reset_caches = N.reset_caches 
 end
 
 (** @canonical Sstt.VDescr *)
@@ -76,7 +75,7 @@ module VDescr = Ty.VDescr
 module Descr = VDescr.Descr
 
 
-(** {2 Components } 
+(** {2 Components }
 
     Components are the building blocks of types. Each component represents a
     union of intersections (a DNF) of a particular "type constructor" (basic
@@ -96,7 +95,7 @@ module Intervals = Descr.Intervals
 (** @canonical Sstt.Enums *)
 module Enums = Descr.Enums
 
-(** {3 Constructor components } 
+(** {3 Constructor components }
 
     Type constructor components come in two flavors: simple constructors such as
     arrows or records and families such as tuples or tagged type. The latter are
@@ -123,8 +122,8 @@ module Tags = Descr.Tags
 (** @canonical Sstt.TagComp *)
 module TagComp = Tags.Comp
 
-(** 
-   {1 Named identifiers} 
+(**
+   {1 Named identifiers}
 
 *)
 
@@ -135,7 +134,7 @@ module TagComp = Tags.Comp
 
 module type NamedIdentifier = Id.NamedIdentifier
 
-(** @inline *) 
+(** @inline *)
 include Base
 
 (** @canonical Sstt.LabelSet *)

--- a/src/lib/sstt/core/node.ml
+++ b/src/lib/sstt/core/node.ml
@@ -120,7 +120,7 @@ include (struct
                                                                             and type row = VDescr.Descr.Records.Atom.t = struct
     (* The PreNode module that contain the entry points of all functions on types. *)
     module NH = Hashtbl.Make(PreNode)
-    module Table = Bttable.MakeOpt(VDescr)(Bool)
+    module Table = Bttable.MakeOpt(PreNode)(Bool)
     type _ Effect.t += GetCache: (Table.t) t
 
     module VDH = Memtable.Make(VDescr)
@@ -158,15 +158,10 @@ include (struct
       t.dependencies <- None ;
       t.simplified <- simplified
 
-
-    let table_size = 1 lsl 19 (* 512k elements*)
+    let table_size = 8192
 
     let cons_table = VDH.create table_size
-    let init_cons_table () =
-      VDH.add cons_table VDescr.empty  empty;
-      VDH.add cons_table VDescr.any any
 
-    let () = init_cons_table ()
     let cons ?(simplified=false) d =
       match VDH.find_opt cons_table d with
         Some n -> n
@@ -200,7 +195,7 @@ include (struct
       | Some s -> s
       | None ->
         let s = t |> def |> VDescr.neg
-          |> cons ~simplified:t.simplified in
+                |> cons ~simplified:t.simplified in
         t.neg <- Some s;
         s.neg <- Some t;
         s
@@ -214,13 +209,6 @@ include (struct
     let conj ts = List.fold_left cap any ts
     let disj ts = List.fold_left cup empty ts
 
-    let reset_caches () =
-      NH2.reset diff_table;
-      NH2.reset cup_table;
-      NH2.reset cap_table;
-      VDH.reset cons_table;
-      init_cons_table ()
-
     let get_cache () = perform GetCache
     let with_own_cache f t =
       let cache = Table.create () in
@@ -229,16 +217,15 @@ include (struct
       | effect GetCache, k -> continue k cache
 
     let is_empty t =
-      let def = def t in
       if t.simplified then
-        VDescr.equal def VDescr.empty
+        VDescr.equal (def t) VDescr.empty
       else
         let cache = get_cache () in
-        begin match Table.find ~default:true cache def with
+        begin match Table.find ~default:true cache t with
           | Some b -> b
           | None ->
-            let b = VDescr.is_empty def in
-            Table.update cache def b;
+            let b = VDescr.is_empty (def t) in
+            Table.update cache t b;
             b
         end
 
@@ -261,9 +248,9 @@ include (struct
       let direct_nodes t = def t |> VDescr.direct_nodes |> NSet.of_list in
       let rec aux ts =
         let ts' = ts
-          |> NSet.to_list
-          |> List.map direct_nodes
-          |> List.fold_left NSet.union ts
+                  |> NSet.to_list
+                  |> List.map direct_nodes
+                  |> List.fold_left NSet.union ts
         in
         if NSet.equal ts ts' then ts' else aux ts'
       in
@@ -285,7 +272,7 @@ include (struct
 
     let of_eqs eqs =
       let deps = eqs
-        |> List.fold_left (fun acc (_, t) -> NSet.union (dependencies t) acc) NSet.empty in
+                 |> List.fold_left (fun acc (_, t) -> NSet.union (dependencies t) acc) NSet.empty in
       let copies = NH.create 10 in
       let () = NSet.iter (fun n -> NH.add copies n (mk ())) deps in
       let new_node n =
@@ -312,7 +299,7 @@ include (struct
                   if has_def nn then Some (v, def nn) else None
                 ) in
               let d = def n |> VDescr.map_nodes new_node
-                |> VDescr.substitute (MixVarMap.of_list1 s) in
+                      |> VDescr.substitute (MixVarMap.of_list1 s) in
               define nn d
             end ;
             define_all (NSet.remove n deps)

--- a/src/lib/sstt/core/node.ml
+++ b/src/lib/sstt/core/node.ml
@@ -86,7 +86,7 @@ include (struct
       }
     let hash t = Hash.int t.id
     let compare t1 t2 = Int.compare t1.id t2.id
-    let equal t1 t2 = Int.equal t1.id t2.id
+    let equal t1 t2 = t1 == t2
     let empty = mk ()
     let any = mk ()
 
@@ -103,7 +103,7 @@ include (struct
       any.dependencies <- Some (NSet.singleton any)
   end
   and Node : Node with type t = AnyEmpty.t and type vdescr = VDescr.t and type descr = VDescr.Descr.t
-                   and type row = VDescr.Descr.Records.Atom.t = struct
+                                                                      and type row = VDescr.Descr.Records.Atom.t = struct
     (* The module which contains any and empty that is passed to Vdescr.Make *)
     include PreNode
     (* We need to duplicate these here, has the one in PreNode are uninitialized  *)
@@ -117,11 +117,23 @@ include (struct
   and NSet : Set.S with type elt = AnyEmpty.t = Set.Make(PreNode) (* Sets of Node.t, but use PreNode to have a well defined cycle *)
   and VDescr : VDescr' with type node = Node.t = Vdescr.Make(Node) (* Instanciate VDescr *)
   and PreNode : PreNode with type t = AnyEmpty.t and type vdescr = VDescr.t and type descr = VDescr.Descr.t
-                         and type row = VDescr.Descr.Records.Atom.t = struct
+                                                                            and type row = VDescr.Descr.Records.Atom.t = struct
     (* The PreNode module that contain the entry points of all functions on types. *)
     module NH = Hashtbl.Make(PreNode)
     module Table = Bttable.MakeOpt(VDescr)(Bool)
     type _ Effect.t += GetCache: (Table.t) t
+
+    module VDH = Memtable.Make(VDescr)
+    module NH2 = Memtable.Make2(
+      struct
+        type t1 = PreNode.t
+        type t2 = PreNode.t
+        let equal t1 t2 s1 s2 =
+          (t1 == s1 && t2 == s2) ||
+          TyRef.(t1.id = s1.id && t2.id = s2.id)
+        let hash t1 t2 =
+          TyRef.(Hash.mix t1.id t2.id)
+      end)
 
     type vdescr = VDescr.t
     type descr = VDescr.Descr.t
@@ -145,16 +157,42 @@ include (struct
       t.def <- Some d ;
       t.dependencies <- None ;
       t.simplified <- simplified
+
+
+    let table_size = 1 lsl 19 (* 512k elements*)
+
+    let cons_table = VDH.create table_size
+    let init_cons_table () =
+      VDH.add cons_table VDescr.empty  empty;
+      VDH.add cons_table VDescr.any any
+
+    let () = init_cons_table ()
     let cons ?(simplified=false) d =
-      let t = mk () in
-      define ~simplified t d ; t
+      match VDH.find_opt cons_table d with
+        Some n -> n
+      | None ->
+        let t = mk () in
+        VDH.add cons_table d t;
+        define ~simplified t d ; t
 
     let of_def d = d |> cons
 
+    let memoize_binop table f =
+      fun t1 t2 ->
+      match NH2.find_opt table t1 t2 with
+        Some v -> v
+      | None ->
+        let t = f t1 t2 in
+        NH2.add table t1 t2 t; t
+
+    let cap_table = NH2.create table_size
     let dcap t1 t2 = VDescr.cap (def t1) (def t2) |> cons
+    let dcap = memoize_binop cap_table dcap
     let cap = fcap ~empty ~any ~cap:dcap
 
+    let cup_table = NH2.create table_size
     let dcup t1 t2 = VDescr.cup (def t1) (def t2) |> cons
+    let dcup = memoize_binop cup_table dcup
     let cup = fcup ~empty ~any ~cup:dcup
 
     let neg t =
@@ -162,17 +200,26 @@ include (struct
       | Some s -> s
       | None ->
         let s = t |> def |> VDescr.neg
-                |> cons ~simplified:t.simplified in
+          |> cons ~simplified:t.simplified in
         t.neg <- Some s;
         s.neg <- Some t;
         s
     let neg = fneg ~empty ~any ~neg
 
+    let diff_table = NH2.create table_size
     let fdiff t1 t2 = VDescr.diff (def t1) (def t2) |> cons
+    let fdiff = memoize_binop diff_table fdiff
     let diff = fdiff_neg ~empty ~any ~neg ~diff:fdiff
 
     let conj ts = List.fold_left cap any ts
     let disj ts = List.fold_left cup empty ts
+
+    let reset_caches () =
+      NH2.reset diff_table;
+      NH2.reset cup_table;
+      NH2.reset cap_table;
+      VDH.reset cons_table;
+      init_cons_table ()
 
     let get_cache () = perform GetCache
     let with_own_cache f t =
@@ -214,9 +261,9 @@ include (struct
       let direct_nodes t = def t |> VDescr.direct_nodes |> NSet.of_list in
       let rec aux ts =
         let ts' = ts
-                  |> NSet.to_list
-                  |> List.map direct_nodes
-                  |> List.fold_left NSet.union ts
+          |> NSet.to_list
+          |> List.map direct_nodes
+          |> List.fold_left NSet.union ts
         in
         if NSet.equal ts ts' then ts' else aux ts'
       in
@@ -238,7 +285,7 @@ include (struct
 
     let of_eqs eqs =
       let deps = eqs
-                 |> List.fold_left (fun acc (_, t) -> NSet.union (dependencies t) acc) NSet.empty in
+        |> List.fold_left (fun acc (_, t) -> NSet.union (dependencies t) acc) NSet.empty in
       let copies = NH.create 10 in
       let () = NSet.iter (fun n -> NH.add copies n (mk ())) deps in
       let new_node n =
@@ -265,7 +312,7 @@ include (struct
                   if has_def nn then Some (v, def nn) else None
                 ) in
               let d = def n |> VDescr.map_nodes new_node
-              |> VDescr.substitute (MixVarMap.of_list1 s) in
+                |> VDescr.substitute (MixVarMap.of_list1 s) in
               define nn d
             end ;
             define_all (NSet.remove n deps)
@@ -275,26 +322,26 @@ include (struct
 
     let substitute s t =
       if MixVarMap.is_empty s then t else
-      let dom = MixVarMap.fold
-        (fun n _ -> MixVarSet.add1 n)
-        (fun r _ -> MixVarSet.add2 r)
-          s MixVarSet.empty in
-      let s = s |> MixVarMap.map1 (fun n -> def n) in
-      (* Optimisation: reuse nodes if possible *)
-      let unchanged n = MixVarSet.disjoint (all_vars n) dom in
-      let deps = dependencies t |> NSet.filter (fun n -> unchanged n |> not) in
-      let copies = NH.create 10 in
-      let () = NSet.iter (fun n -> NH.add copies n (mk ())) deps in
-      let new_node n =
-        match NH.find_opt copies n with
-        | Some n -> n
-        | None -> n
-      in
-      deps |> NSet.iter (fun n ->
-          let d = def n |> VDescr.map_nodes new_node |> VDescr.substitute s in
-          define (new_node n) d
-        ) ;
-      new_node t
+        let dom = MixVarMap.fold
+            (fun n _ -> MixVarSet.add1 n)
+            (fun r _ -> MixVarSet.add2 r)
+            s MixVarSet.empty in
+        let s = s |> MixVarMap.map1 (fun n -> def n) in
+        (* Optimisation: reuse nodes if possible *)
+        let unchanged n = MixVarSet.disjoint (all_vars n) dom in
+        let deps = dependencies t |> NSet.filter (fun n -> unchanged n |> not) in
+        let copies = NH.create 10 in
+        let () = NSet.iter (fun n -> NH.add copies n (mk ())) deps in
+        let new_node n =
+          match NH.find_opt copies n with
+          | Some n -> n
+          | None -> n
+        in
+        deps |> NSet.iter (fun n ->
+            let d = def n |> VDescr.map_nodes new_node |> VDescr.substitute s in
+            define (new_node n) d
+          ) ;
+        new_node t
 
     let factorize t =
       let cache = NH.create 10 in
@@ -328,6 +375,6 @@ include (struct
 
 end : sig (* Hide everything, we could also add that in a .mli file. *)
            module rec Node : (Node with type vdescr = VDescr.t and type descr = VDescr.Descr.t
-                                    and type row=VDescr.Descr.Records.Atom.t)
+                                                               and type row=VDescr.Descr.Records.Atom.t)
            and VDescr : VDescr with type node = Node.t
          end)

--- a/src/lib/sstt/core/sigs.ml
+++ b/src/lib/sstt/core/sigs.ml
@@ -1088,12 +1088,11 @@ module type PreNode = sig
   val all_vars : t -> MixVarSet.t
   val all_vars_toplevel : t -> MixVarSet.t
   val nodes : t -> t list
-
   val of_eqs : (Var.t * t) list -> (Var.t * t) list
   val substitute : subst -> t -> t
   val factorize : t -> t
   val simplify : t -> unit
-
+  val reset_caches : unit -> unit
 end
 module type Node = sig
   include PreNode
@@ -1214,7 +1213,10 @@ module type Ty = sig
   (** [factorize t] factorizes equivalent nodes in [t].
       This operation may be expensive since it calls {!equiv} internally.
   *)
-
+  
+  val reset_caches : unit -> unit
+  (** [reset_caches ()] clears the internal tables used to cache the result of
+    set-theoretic operations.*)
 
   (** {1 Field types and optional types }*)
 

--- a/src/lib/sstt/core/sigs.ml
+++ b/src/lib/sstt/core/sigs.ml
@@ -15,14 +15,6 @@ module type Comparable = sig
   *)
 end
 
-module type Comparable' = sig
-  type t
-  type node
-  val compare' : (node -> node -> int) -> t -> t -> int
-  val equal' : (node -> node -> bool) -> t -> t -> bool
-  val hash' : (node -> int) -> t -> int
-end
-
 module type TyBase = sig
   type t
 
@@ -297,8 +289,6 @@ module type OTy = sig
 
     include TyBase with type node := node and type t := t (** @inline *)
 
-    include Comparable' with type node := node and type t := t (** @inline *)
-
     val absent : t
     (** [absent] is the singleton type containing the undefined value, {m \bot}. *)
 
@@ -416,8 +406,6 @@ module type FTy = sig
     and type leaf := OTy.t and type var := RowVar.t
     and module VarSet := RowVarSet
     and module VarMap := RowVarMap
-
-  include Comparable' with type node := node and type t := t (** @inline *)
 
 end
 
@@ -673,7 +661,7 @@ module type Records = sig
   *)
 
   type node
-  
+
   (** @canonical Sstt.Ty.F *)
   module FTy : FTy with type node := node
 
@@ -1092,7 +1080,6 @@ module type PreNode = sig
   val substitute : subst -> t -> t
   val factorize : t -> t
   val simplify : t -> unit
-  val reset_caches : unit -> unit
 end
 module type Node = sig
   include PreNode
@@ -1192,7 +1179,7 @@ module type Ty = sig
   *)
 
   val all_vars : t -> MixVarSet.t
-  
+
   val all_vars_toplevel : t -> MixVarSet.t
 
   val nodes : t -> t list
@@ -1213,10 +1200,6 @@ module type Ty = sig
   (** [factorize t] factorizes equivalent nodes in [t].
       This operation may be expensive since it calls {!equiv} internally.
   *)
-  
-  val reset_caches : unit -> unit
-  (** [reset_caches ()] clears the internal tables used to cache the result of
-    set-theoretic operations.*)
 
   (** {1 Field types and optional types }*)
 

--- a/src/lib/sstt/core/utils/bdd.ml
+++ b/src/lib/sstt/core/utils/bdd.ml
@@ -46,15 +46,8 @@ module Make(N:Atom)(L:Leaf) = struct
     | Node (_, _, _, h) -> h
 
   let hleaf l = Leaf (l, Hash.mix Hash.const2 (L.hash l))
-  let hnode a p n = Node (a, p, n, 
+  let hnode a p n = Node (a, p, n,
                           Hash.mix3 (N.hash a) (hash p) (hash n) )
-
-  (* Version less optimized but parametric *)
-  let rec hash' hn hl t =
-    match t with
-    | Leaf (l, _) -> hl l
-    | Node (a, p, n, _)->
-      Hash.mix3 (hn a) (hash' hn hl p) (hash' hn hl n)
 
   let empty = hleaf L.empty
   let any = hleaf L.any
@@ -70,15 +63,6 @@ module Make(N:Atom)(L:Leaf) = struct
     | Node (a1, p1, n1, h1), Node (a2, p2, n2, h2) ->
       Int.equal h1 h2 &&
       N.equal a1 a2 && equal p1 p2 && equal n1 n2
-  
-  (* Version less optimized but parametric *)
-  let rec equal' fn fl t1 t2 =
-    t1 == t2 ||
-    match t1, t2 with
-    | Leaf (l1, _) , Leaf (l2, _) -> fl l1 l2
-    | Node _, Leaf _ | Leaf _, Node _ -> false
-    | Node (a1, p1, n1, _), Node (a2, p2, n2, _) ->
-      fn a1 a2 && equal' fn fl p1 p2 && equal' fn fl n1 n2
 
   let rec compare t1 t2 =
     if t1 == t2 then 0 else
@@ -91,18 +75,6 @@ module Make(N:Atom)(L:Leaf) = struct
           let c = N.compare a1 a2 in if c <> 0 then c else
             let c = compare p1 p2 in if c <> 0 then c else
               compare n1 n2
-
-  (* Version less optimized but parametric *)
-  let rec compare' fn fl t1 t2 =
-    if t1 == t2 then 0 else
-      match t1, t2 with
-      | Leaf (l1, _), Leaf (l2, _) -> fl l1 l2
-      | Leaf _, Node _ -> 1
-      | Node _, Leaf _ -> -1
-      | Node (a1, p1, n1, _), Node (a2, p2, n2, _) ->
-        let c = fn a1 a2 in if c <> 0 then c else
-          let c = compare' fn fl p1 p2 in if c <> 0 then c else
-            compare' fn fl n1 n2
 
   (* Smart constructor *)
   let node a p n =

--- a/src/lib/sstt/core/utils/memtable.ml
+++ b/src/lib/sstt/core/utils/memtable.ml
@@ -1,0 +1,112 @@
+module type HashedPair = sig
+  type t1
+  type t2
+  val hash : t1 -> t2 -> int
+  val equal : t1 -> t2 -> t1 -> t2 -> bool
+end
+
+module Make2 (H : HashedPair) = struct
+  type 'a entry =
+    | Empty
+    | Slot of H.t1 * H.t2 * 'a option
+
+  type 'a t = {
+    mutable data : 'a entry array;
+    initial : int;
+    mutable size : int;
+    mutable mask : int;
+  }
+
+  let initial_capacity n =
+    let c = ref 1 in
+    while !c < n do c := !c lsl 1 done;
+    !c
+
+  let create n =
+    let cap = initial_capacity (max n 4) in
+    let table =
+      { data = Array.make cap Empty; size = 0; initial = cap; mask = cap - 1 }
+    in
+    table
+
+  let clear t =
+    Array.fill t.data 0 (Array.length t.data) Empty;
+    t.size <- 0
+  let reset t =
+    t.data <- Array.make t.initial Empty;
+    t.mask <- t.initial - 1;
+    t.size <- 0
+
+  let[@inline always] find_slot data mask key1 key2 =
+    let rec loop h =
+      match Array.unsafe_get data h with
+      | Empty -> - h - 2
+      | Slot (k1, k2, _) ->
+        if H.equal k1 k2 key1 key2 then h
+        else loop ((h+1) land mask)
+    in
+    loop ((H.hash key1 key2) land mask)
+
+  let insert_no_check data mask key1 key2 o =
+    let h = ref ((H.hash key1 key2) land mask) in
+    while Array.get data !h <> Empty do
+      h := (!h + 1) land mask
+    done;
+    data.(!h) <- Slot (key1, key2, o)
+
+  let resize t =
+    let old_data = t.data in
+    let new_cap = Array.length old_data lsl 1 in
+    let new_mask = new_cap - 1 in
+    let new_data = Array.make new_cap Empty in
+    Array.iter (function
+        | Empty -> ()
+        | Slot (k1, k2, o) -> insert_no_check new_data new_mask k1 k2 o
+      ) old_data;
+    t.data <- new_data;
+    t.mask <- new_mask
+
+  let find_opt { data; mask; _ }  key1 key2 =
+    let i = find_slot data mask key1 key2 in
+    if i >= 0 then match Array.unsafe_get data i with
+      | Slot (_,_, o) -> o
+      | Empty -> assert false
+    else None
+
+  let find t key1 key2 =
+    match find_opt t key1 key2 with
+    | Some v -> v
+    | None -> raise Not_found
+
+  let calc_size n t = (n lsl 2) > (t lsl 1) + t (* n > 3t/4*)
+  let add t key1 key2 value =
+    let i = find_slot t.data t.mask key1 key2 in
+    let o = Some value in
+    if i >= 0 then
+      t.data.(i) <- Slot (key1, key2, o)
+    else begin
+      if calc_size t.size (Array.length t.data) then begin
+        resize t;
+        insert_no_check t.data t.mask key1 key2 o
+      end else
+        t.data.(- i - 2) <- Slot (key1, key2, o);
+      t.size <- t.size + 1
+    end
+
+  let length t = t.size
+end
+
+module Make (H : Hashtbl.HashedType) = struct
+  module H2 =
+  struct
+    type t1 = H.t
+    type t2 = unit
+    let hash t1 () = H.hash t1
+    let equal t1 () t2 () = H.equal t1 t2
+  end
+  include Make2(H2)
+  let add t k v = add t k () v
+  let find t k = find t k ()
+  let find_opt t k = find_opt t k ()
+
+end

--- a/src/lib/sstt/core/utils/memtable.ml
+++ b/src/lib/sstt/core/utils/memtable.ml
@@ -6,15 +6,13 @@ module type HashedPair = sig
 end
 
 module Make2 (H : HashedPair) = struct
-  type 'a entry =
-    | Empty
-    | Slot of H.t1 * H.t2 * 'a option
+  type 'a entry = int * H.t1 * H.t2 * 'a
 
   type 'a t = {
-    mutable data : 'a entry array;
-    initial : int;
+    mutable data : 'a entry Weak.t;
     mutable size : int;
     mutable mask : int;
+    initial : int;
   }
 
   let initial_capacity n =
@@ -23,73 +21,68 @@ module Make2 (H : HashedPair) = struct
     !c
 
   let create n =
-    let cap = initial_capacity (max n 4) in
-    let table =
-      { data = Array.make cap Empty; size = 0; initial = cap; mask = cap - 1 }
-    in
-    table
+    let cap = initial_capacity (max n 64) in
+    { data = Weak.create cap; size = 0; mask = cap - 1; initial = cap; }
 
   let clear t =
-    Array.fill t.data 0 (Array.length t.data) Empty;
+    Weak.fill t.data 0 (Weak.length t.data) None;
     t.size <- 0
   let reset t =
-    t.data <- Array.make t.initial Empty;
+    t.data <- Weak.create t.initial;
     t.mask <- t.initial - 1;
     t.size <- 0
 
-  let[@inline always] find_slot data mask key1 key2 =
-    let rec loop h =
-      match Array.unsafe_get data h with
-      | Empty -> - h - 2
-      | Slot (k1, k2, _) ->
-        if H.equal k1 k2 key1 key2 then h
-        else loop ((h+1) land mask)
+  let[@inline always] find_slot init_h data mask key1 key2 =
+    let rec loop init_h h =
+      match Weak.get data h with
+      | None -> - h - 2, None
+      | Some (cur_h, k1, k2, o) ->
+        if cur_h = init_h && H.equal k1 k2 key1 key2 then h, Some o
+        else loop init_h ((h + 1) land mask)
     in
-    loop ((H.hash key1 key2) land mask)
+    loop init_h (init_h land mask)
 
-  let insert_no_check data mask key1 key2 o =
-    let h = ref ((H.hash key1 key2) land mask) in
-    while Array.get data !h <> Empty do
+  let insert_no_check init_h data mask o =
+    let h = ref (init_h land mask) in
+    while Weak.check data !h do
       h := (!h + 1) land mask
     done;
-    data.(!h) <- Slot (key1, key2, o)
+    Weak.set data !h o
 
   let resize t =
     let old_data = t.data in
-    let new_cap = Array.length old_data lsl 1 in
+    let new_cap = Weak.length old_data lsl 1 in
     let new_mask = new_cap - 1 in
-    let new_data = Array.make new_cap Empty in
-    Array.iter (function
-        | Empty -> ()
-        | Slot (k1, k2, o) -> insert_no_check new_data new_mask k1 k2 o
-      ) old_data;
+    let new_data = Weak.create new_cap in
+    for i = 0 to Weak.length old_data - 1 do
+      match Weak.get old_data i with
+      | None -> ()
+      | Some (init_h, _, _, _) as o -> insert_no_check init_h new_data new_mask o
+    done;
     t.data <- new_data;
     t.mask <- new_mask
 
-  let find_opt { data; mask; _ }  key1 key2 =
-    let i = find_slot data mask key1 key2 in
-    if i >= 0 then match Array.unsafe_get data i with
-      | Slot (_,_, o) -> o
-      | Empty -> assert false
-    else None
+  let find_opt { data; mask; _ } key1 key2 =
+    let _,o = find_slot (H.hash key1 key2) data mask key1 key2 in o
 
   let find t key1 key2 =
     match find_opt t key1 key2 with
     | Some v -> v
     | None -> raise Not_found
 
-  let calc_size n t = (n lsl 2) > (t lsl 1) + t (* n > 3t/4*)
-  let add t key1 key2 value =
-    let i = find_slot t.data t.mask key1 key2 in
-    let o = Some value in
+  let calc_size n t = (n lsl 2) > (t lsl 1) + t (* n > 0.75 t *)
+  let add t key1 key2 v =
+    let init_h = H.hash key1 key2 in
+    let i,_ = find_slot init_h t.data t.mask key1 key2 in
+    let o = Some (init_h, key1, key2, v) in
     if i >= 0 then
-      t.data.(i) <- Slot (key1, key2, o)
+      Weak.set t.data (i) o
     else begin
-      if calc_size t.size (Array.length t.data) then begin
+      if calc_size t.size (Weak.length t.data) then begin
         resize t;
-        insert_no_check t.data t.mask key1 key2 o
+        insert_no_check init_h t.data t.mask  o
       end else
-        t.data.(- i - 2) <- Slot (key1, key2, o);
+        Weak.set t.data (- i - 2) o;
       t.size <- t.size + 1
     end
 

--- a/src/lib/sstt/core/utils/memtable.mli
+++ b/src/lib/sstt/core/utils/memtable.mli
@@ -1,0 +1,32 @@
+module Make :
+  (H : Hashtbl.HashedType) ->
+    sig
+      type 'a t
+      val create : int -> 'a t
+      val clear : 'a t -> unit
+      val reset : 'a t -> unit
+      val find_opt : 'a t -> H.t -> 'a option
+      val find : 'a t -> H.t -> 'a
+      val add : 'a t -> H.t -> 'a -> unit
+      val length : 'a t -> int
+    end
+
+module type HashedPair = sig
+       type t1
+       type t2
+       val hash : t1 -> t2 -> int
+       val equal : t1 -> t2 -> t1 -> t2 -> bool
+end
+
+module Make2 :
+  (H : HashedPair) ->
+    sig
+      type 'a t
+      val create : int -> 'a t
+      val clear : 'a t -> unit
+      val reset : 'a t -> unit
+      val find_opt : 'a t -> H.t1 -> H.t2 -> 'a option
+      val find : 'a t -> H.t1 -> H.t2 -> 'a
+      val add : 'a t -> H.t1 -> H.t2 -> 'a -> unit
+      val length : 'a t -> int
+    end

--- a/src/lib/sstt/types/tallying.ml
+++ b/src/lib/sstt/types/tallying.ml
@@ -393,29 +393,11 @@ module Make(VS:VarSettings) = struct
 
   (* Caching modules *)
 
-  module VDHash = Hashtbl.Make(VDescr)
-  module FDescr = struct
-    (* Intuitively, this module represents a field descriptor in which
-       direct nodes have been inlined. It is used for caching:
-       to ensure termination, caching of field types should be done
-       by comparing the descriptor of the underlying nodes and not only their id. *)
-
-    module TyHash = Hashtbl.Make(Ty)
-    type t = Ty.F.t * VDescr.t TyHash.t
-    let of_field f =
-      let h = TyHash.create 3 in
-      let cache n = TyHash.replace h n (Ty.def n) ; n in
-      Ty.F.map_nodes cache f |> ignore ;
-      f, h
-    let equal (f1,h1) (f2,h2) = Ty.F.equal'
-      (fun n1 n2 -> VDescr.equal (TyHash.find h1 n1) (TyHash.find h2 n2))
-      f1 f2
-    let hash (f,h) = f |> Ty.F.hash' (fun n -> VDescr.hash (TyHash.find h n))
-  end
-  module FDHash = Hashtbl.Make(FDescr)
+  module TyHash = Hashtbl.Make(Ty)
+  module FTyHash = Hashtbl.Make(Ty.F)
 
   (* Core tallying algorithm *)
-  
+
   let norm_tuple_gen ~diff ~disjoint ~norm ps ns =
     (* Same algorithm as for subtyping tuples.
        We define it outside norm below so that its type can be
@@ -434,19 +416,20 @@ module Make(VS:VarSettings) = struct
     in psi CSS.any ps ns ()
 
   let norm, norm_field =
-    let memo_ty = VDHash.create 17 in
-    let memo_f = FDHash.create 17 in
+    let memo_ty = TyHash.create 17 in
+    let memo_f = FTyHash.create 17 in
     let rec norm_ty t =
       if Ty.is_empty t then CSS.any
       else if MixVarSet.subset (Ty.all_vars t) VS.delta then CSS.empty
-      else norm_vdescr (Ty.def t)
-    and norm_vdescr vd =
-      match VDHash.find_opt memo_ty vd with
+      else norm_vdescr t
+    and norm_vdescr t =
+      match TyHash.find_opt memo_ty t with
       | Some cstr -> cstr
       | None ->
-        VDHash.add memo_ty vd CSS.any;
+        TyHash.add memo_ty t CSS.any;
+        let vd = Ty.def t in
         let res = vd |> VDescr.dnf |> CSS.map_conj norm_summand in
-        VDHash.remove memo_ty vd ; res
+        TyHash.remove memo_ty t ; res
     and norm_summand summand =
       match VToplevel.extract_smallest summand with
       | None ->
@@ -480,7 +463,7 @@ module Make(VS:VarSettings) = struct
       else cs |> CSS.map_conj norm_tagcomp
     and norm_tagcomp c =
       let tag = TagComp.tag c in
-      c |> TagComp.dnf |> CSS.map_conj (norm_tag tag)      
+      c |> TagComp.dnf |> CSS.map_conj (norm_tag tag)
     and norm_arrows arr =
       arr |> Arrows.dnf |> CSS.map_conj norm_arrow
     and norm_tuples tup =
@@ -539,13 +522,12 @@ module Make(VS:VarSettings) = struct
       in
       norm_tuple_gen ~diff:Ty.F.diff ~disjoint ~norm:norm_field p ns
     and norm_field (f:Ty.F.t) =
-      let fd = FDescr.of_field f in
-      match FDHash.find_opt memo_f fd with
+      match FTyHash.find_opt memo_f f with
       | Some cstr -> cstr
       | None ->
-        FDHash.add memo_f fd CSS.any;
+        FTyHash.add memo_f f CSS.any;
         let res = f |> Ty.F.dnf |> CSS.map_conj norm_field_summand in
-        FDHash.remove memo_f fd ; res
+        FTyHash.remove memo_f f ; res
     and norm_field_summand summand =
       match FToplevel.extract_smallest summand with
       | None ->
@@ -558,8 +540,8 @@ module Make(VS:VarSettings) = struct
     norm_ty, norm_field
 
   let propagate cs =
-    let memo_ty = VDHash.create 17 in
-    let memo_f = FDHash.create 17 in
+    let memo_ty = TyHash.create 17 in
+    let memo_f = FTyHash.create 17 in
     let rec aux (prev,prev') ((cs,cs') : CS'.t) =
       let retry_with css =
         let css' () = CS'.cap (prev,prev') (cs,cs') |> CSS.singleton in
@@ -571,23 +553,21 @@ module Make(VS:VarSettings) = struct
       | Cons (constr, tl), _ ->
         let (t', _, t) = VC.destruct constr in
         let ty = Ty.diff t' t in
-        let def = Ty.def ty in
-        if VDHash.mem memo_ty def then
+        if TyHash.mem memo_ty ty then
           aux (VCS.add constr prev, prev') (tl,cs')
         else
-          let () = VDHash.add memo_ty def () in
+          let () = TyHash.add memo_ty ty () in
           let res = norm ty |> retry_with in
-          VDHash.remove memo_ty def ; res
+          TyHash.remove memo_ty ty ; res
       | Nil, Cons (constr, tl) ->
         let (f', _, f) = FC.destruct constr in
         let f = Ty.F.diff f' f in
-        let def = FDescr.of_field f in
-        if FDHash.mem memo_f def then
+        if FTyHash.mem memo_f f then
           aux (prev, FCS.add constr prev') (cs,tl)
         else
-          let () = FDHash.add memo_f def () in
+          let () = FTyHash.add memo_f f () in
           let res = norm_field f |> retry_with in
-          FDHash.remove memo_f def ; res
+          FTyHash.remove memo_f f ; res
     in
     aux CS'.any cs
 

--- a/src/tests/tests.ml
+++ b/src/tests/tests.ml
@@ -81,15 +81,15 @@ let%expect_test "tests" =
     var3: empty
     var4: any
     var5: 'x
-    print1: (int -> bool -> true) | (any -> any)
+    print1: (any -> any) | (int -> bool -> true)
     print2: (false, false) | (true, true)
-    print3: { l1 : true ; l2 : true ..} | { l1 : false ; l2 : true }
+    print3: { l1 : false ; l2 : true } | { l1 : true ; l2 : true ..}
     print4: nil | int | (any, x1) where x1 = nil | (any, x1)
     print5: (int -> int) -> bool -> bool
     print6: 'b & ('a, 'b) | 'a
     print7: ~true
     print8: ~(any -> bool)
-    print9: ~((true -> false) & (any -> bool))
+    print9: ~((any -> bool) & (true -> false))
     print10: ~((false, true) | (true, false))
     print11: bool
     print13: 'y
@@ -149,12 +149,12 @@ let%expect_test "tests" =
               'Y: empty
             ]
     tally10: [
-               'Y: empty
-             ]
-             [
                'Y: 'Y & 'y ;
                'A: 'A | 'a ;
                'B: 'B & 'b
+             ]
+             [
+               'Y: empty
              ]
     tally11: [
                'X: 'X | 'a | 'b ;
@@ -295,7 +295,7 @@ let%expect_test "tests_ext" =
       list_42_43: [ 42 43 any* ]
       int_list: [ int* ]
       list_not_only_a: [ any any* (~'a) any* | (~'a) any* ]
-      list_union: [ 42 any* | 43 42 any* ]
+      list_union: [ 43 42 any* | 42 any* ]
       list_regexp: [ ('a | 'b)* ]
       list_with_vars: 42::('a & [ int* ])
       char_any: char

--- a/src/tests/tests.ml
+++ b/src/tests/tests.ml
@@ -21,7 +21,7 @@ let%expect_test "tests" =
     empty2: true
     atom1: false
     atom2: true
-    tags1: tag((true, false) | (false, true))
+    tags1: tag((false, true) | (true, false))
     tags2: tag1(true, false) | tag2(false, true)
     tags3: true
     tags4: 42
@@ -81,23 +81,23 @@ let%expect_test "tests" =
     var3: empty
     var4: any
     var5: 'x
-    print1: (any -> any) | (int -> bool -> true)
-    print2: (true, true) | (false, false)
-    print3: { l1 : false ; l2 : true } | { l1 : true ; l2 : true ..}
+    print1: (int -> bool -> true) | (any -> any)
+    print2: (false, false) | (true, true)
+    print3: { l1 : true ; l2 : true ..} | { l1 : false ; l2 : true }
     print4: nil | int | (any, x1) where x1 = nil | (any, x1)
     print5: (int -> int) -> bool -> bool
     print6: 'b & ('a, 'b) | 'a
     print7: ~true
     print8: ~(any -> bool)
-    print9: ~((any -> bool) & (true -> false))
-    print10: ~((true, false) | (false, true))
+    print9: ~((true -> false) & (any -> bool))
+    print10: ~((false, true) | (true, false))
     print11: bool
     print13: 'y
     print14: nil, (bool, x1) where x1 = nil | (bool, x1)
     print15: tuple \ tuple2
     print16: ~(40..44)
     print17: ~tag(42)
-    print18: ('a -> 'b) & ('c -> 'd) & ~('e -> 'f) & ~('g -> 'h)
+    print18: ('c -> 'd) & ('a -> 'b) & ~('g -> 'h) & ~('e -> 'f)
     print19: tag \ sometag(unit)
     print20: ~(bool | int | unit)
     tally1:
@@ -115,11 +115,11 @@ let%expect_test "tests" =
               'Y: 'Y & 'y
             ]
     tally6: [
-              'Z: empty
-            ]
-            [
               'X: 'Z | 'X ;
               'Y: 'Y & bool
+            ]
+            [
+              'Z: empty
             ]
     tally7: [
               'X: empty
@@ -181,11 +181,11 @@ let%expect_test "tests" =
                'Y: bool
              ]
     tally16: [
-               'A: empty
-             ]
-             [
                'X: 'A | 'X ;
                'Y: 'B & 'Y
+             ]
+             [
+               'A: empty
              ]
     tally17: [
                'X: int | 'X ;
@@ -295,8 +295,8 @@ let%expect_test "tests_ext" =
       list_42_43: [ 42 43 any* ]
       int_list: [ int* ]
       list_not_only_a: [ any any* (~'a) any* | (~'a) any* ]
-      list_union: [ 43 42 any* | 42 any* ]
-      list_regexp: [ ('b | 'a)* ]
+      list_union: [ 42 any* | 43 42 any* ]
+      list_regexp: [ ('a | 'b)* ]
       list_with_vars: 42::('a & [ int* ])
       char_any: char
       char_union: ('\000'-'1') | ('e'-'\255')


### PR DESCRIPTION
This is a draft pull request for the moment.

This PR experiments with caching the result of node operations. The operations cached are:
- `Node.cons` (which puts the `VDescr.t` insides a `Node.t`). It uses a `VDescr.t` indexed memoization table to not allocate a new node if one already exists with the same descriptor.
- `Node.cap`/`Node.cup`/`Node.diff` 

I designed a custom hash-table which fits the purpose of memoization better than the generic `Hashtbl` module of OCaml. The table is specialized to accept two keys (useful to cache binary operations) without requiring to pack them in a tuple (which allocates and defeats the purpose of having a fast path). For unary functions (such as `cons`) one can use `unit` as second key with no overhead. The implementation uses linear probing (rather than buckets) in the hop that there won't be many conflicts, which is the case if initial tables are sufficiently large (I settled on 512k elements, but the table grows if needed).

The results are encouraging. On my machine, on MLsem's `main` branch:
```
./bench.sh time
Run 1 ... 4.19
Run 2 ... 4.23
Run 3 ... 4.18
Run 4 ... 4.17
Total of 4 runs: 4.19
dune exec -- src/bin/native.exe test_objects.ml
                                       
===== Processing test_objects.ml =====
diverge: any -> empty (checked in 1ms)
magic: empty (checked in 0ms)
an_integer: ∀'a,'b,'c. x2 where x1 = (x2 -> (x2, x2)) & (~{ _name : (~(Numeric_ |
Integer_))? ; plus : (x2 -> x2) & ({ _name : (~enum)? ; coerce : x2 -> ('b &
_add_('c, 'a), 'c) ..} -> 'a) ; coerce : x1 } -> (float, float)) and x2 = {
_name : (~(Numeric_ | Integer_))? ; plus : (x2 -> x2) & ({ _name : (~enum)? ;
coerce : x2 -> ('b & _add_('c, 'a), 'c) ..} -> 'a) ; coerce : x1 } (checked in 12ms)
test0: ∀'a,'b,'c. x2 where x1 = (x2 -> (x2, x2)) & (~{ _name : (~(Numeric_ |
Integer_))? ; plus : (x2 -> x2) & ({ _name : (~enum)? ; coerce : x2 -> ('b &
{ plus : 'c -> 'a ..}, 'c) ..} -> 'a) ; coerce : x1 } -> (float, float)) and
x2 = { _name : (~(Numeric_ | Integer_))? ; plus : (x2 -> x2) & ({ _name :
(~enum)? ; coerce : x2 -> ('b & { plus : 'c -> 'a ..}, 'c) ..} -> 'a) ;
coerce : x1 } (checked in 64042ms)
Total time: 64.06s
```
with this commit:
```
/bench.sh time
Run 1 ... 4.79
Run 2 ... 4.88
Run 3 ... 4.86
Run 4 ... 4.86
Total of 4 runs: 4.84
dune exec -- src/bin/native.exe test_objects.ml
                                       
===== Processing test_objects.ml =====
diverge: any -> empty (checked in 1ms)
magic: empty (checked in 0ms)
an_integer: ∀'a,'b,'c. x2 where x1 = (x2 -> (x2, x2)) & (~{ _name : (~(Numeric_ |
Integer_))? ; plus : (x2 -> x2) & ({ _name : (~enum)? ; coerce : x2 -> ('b &
_add_('c, 'a), 'c) ..} -> 'a) ; coerce : x1 } -> (float, float)) and x2 = {
_name : (~(Numeric_ | Integer_))? ; plus : (x2 -> x2) & ({ _name : (~enum)? ;
coerce : x2 -> ('b & _add_('c, 'a), 'c) ..} -> 'a) ; coerce : x1 } (checked in 13ms)
test0: ∀'a,'b,'c. x2 where x1 = (x2 -> (x2, x2)) & (~{ _name : (~(Numeric_ |
Integer_))? ; plus : (x2 -> x2) & ({ _name : (~enum)? ; coerce : x2 -> ('b &
{ plus : 'c -> 'a ..}, 'c) ..} -> 'a) ; coerce : x1 } -> (float, float)) and
x2 = { _name : (~(Numeric_ | Integer_))? ; plus : (x2 -> x2) & ({ _name :
(~enum)? ; coerce : x2 -> ('b & { plus : 'c -> 'a ..}, 'c) ..} -> 'a) ;
coerce : x1 } (checked in 7708ms)
Total time: 7.73s
```
So without doing anything, the regular test suite is a bit slower and on hard example much faster (9x).
However, if one performs `Sstt.Ty.reset_caches()` between each files in MLsem's `native.ml`
then the timing is now:
```
./bench.sh time
Run 1 ... 4.25
Run 2 ... 4.24
Run 3 ... 4.18
Run 4 ... 4.15
Total of 4 runs: 4.20
```
So virtually the same as on main which is great. This can be explained as if one does not reset between files, the cache is full of types unrelated to the current file.

I'm leaving this as a draft for now to discuss things. One opportunity that arises is that now Node can be used for subtyping and tallying instead of VDescr… however on preliminary tests, this seems to make things *slower* not faster, so more investigation is needed to use nodes for caching subtyping/tallying.

