### PR TITLE
Effect shared cache

### DIFF
--- a/src/lib/sstt/core/components/arrows.ml
+++ b/src/lib/sstt/core/components/arrows.ml
@@ -54,8 +54,8 @@ module Make(N:Node) = struct
     let leq t1 t2 = leq (Bdd.of_dnf t1) (Bdd.of_dnf t2)
   end
   module Dnf = Dnf.LMake(Comp)
-  let dnf t = N.with_own_cache (fun t -> Bdd.dnf t |> Dnf.export) t
-  let of_dnf dnf = N.with_own_cache (fun dnf -> Dnf.import dnf |> Bdd.of_dnf) dnf
+  let dnf t = Bdd.dnf t |> Dnf.export
+  let of_dnf dnf = Dnf.import dnf |> Bdd.of_dnf
 
   let direct_nodes t = Bdd.atoms t |> List.concat_map Atom.direct_nodes
   let map_nodes f t = Bdd.map_nodes (Atom.map_nodes f) t

--- a/src/lib/sstt/core/components/fields.ml
+++ b/src/lib/sstt/core/components/fields.ml
@@ -80,9 +80,6 @@ module OTy(N:Node) = struct
   let equal = Bdd.equal
   let compare = Bdd.compare
   let hash = Bdd.hash
-  let equal' f = Bdd.equal' (Atom.equal' f) (BoolLeaf.equal)
-  let compare' f = Bdd.compare' (Atom.compare' f) (BoolLeaf.compare)
-  let hash' f = Bdd.hash' (Atom.hash' f) (BoolLeaf.hash)
 
   let leq t1 t2 = diff t1 t2 |> is_empty
   let equiv t1 t2 = leq t1 t2 && leq t2 t1
@@ -92,20 +89,17 @@ module OTy(N:Node) = struct
     let leq t1 t2 = leq (Bdd.of_dnf t1) (Bdd.of_dnf t2)
   end
   module Dnf = Dnf.LMake(Comp)
-  let dnf t = N.with_own_cache (fun t -> Bdd.dnf t |> Dnf.export) t
-  let of_dnf dnf = N.with_own_cache (fun dnf -> Dnf.import dnf |> Bdd.of_dnf) dnf
+  let dnf t = Bdd.dnf t |> Dnf.export
+  let of_dnf dnf = Dnf.import dnf |> Bdd.of_dnf
 
   let direct_nodes t = Bdd.atoms t |> List.concat_map Atom.direct_nodes
   let map_nodes f t = Bdd.map_nodes (Atom.map_nodes f) t
   let map f t = Bdd.map_nodes f t
   let simplify t = Bdd.simplify equiv t
+
 end
 
 module Make(N:Node) = struct
   module OTy = OTy(N)
-  include Polymorphic.Make(N)(RowVar)(OTy)
-
-  let equal' f = Bdd.equal' RowVar.equal (OTy.equal' f)
-  let compare' f = Bdd.compare' RowVar.compare (OTy.compare' f)
-  let hash' f = Bdd.hash' RowVar.hash (OTy.hash' f)
+  include Polymorphic.Make(RowVar)(OTy)
 end

--- a/src/lib/sstt/core/components/records.ml
+++ b/src/lib/sstt/core/components/records.ml
@@ -241,10 +241,10 @@ module Make(N:Node) = struct
       if is_empty res then None else Some (simplify res)
   end
   module Dnf = Dnf.LMake'(Comp)
-  let dnf t = N.with_own_cache (fun t -> Bdd.dnf t |> Dnf.export) t
-  let dnf' t = N.with_own_cache (fun t -> Bdd.dnf t |> Dnf.export') t
-  let of_dnf dnf = N.with_own_cache (fun dnf -> Dnf.import dnf |> Bdd.of_dnf) dnf
-  let of_dnf' dnf' = N.with_own_cache (fun dnf' -> Dnf.import' dnf' |> Bdd.of_dnf) dnf'
+  let dnf t = Bdd.dnf t |> Dnf.export
+  let dnf' t = Bdd.dnf t |> Dnf.export'
+  let of_dnf dnf = Dnf.import dnf |> Bdd.of_dnf
+  let of_dnf' dnf' = Dnf.import' dnf' |> Bdd.of_dnf
 
   let direct_nodes t = Bdd.atoms t |> List.concat_map Atom.direct_nodes
   let map_nodes f t = Bdd.map_nodes (Atom.map_nodes f) t

--- a/src/lib/sstt/core/components/tags.ml
+++ b/src/lib/sstt/core/components/tags.ml
@@ -91,10 +91,10 @@ module MakeC(N:Node) = struct
 
   let dnf (tag, bdd) =
     let (export,_) = dnf_funs tag in
-    N.with_own_cache (fun bdd -> Bdd.dnf bdd |> export) bdd
+    Bdd.dnf bdd |> export
   let of_dnf tag dnf =
     let (_,import) = dnf_funs tag in
-    N.with_own_cache (fun dnf -> tag, import dnf |> Bdd.of_dnf) dnf
+    tag, import dnf |> Bdd.of_dnf
 
   let direct_nodes (_,t) = Bdd.atoms t |> List.concat_map Atom.direct_nodes
   let map_nodes f (tag,t) = tag, Bdd.map_nodes (Atom.map_nodes f) t

--- a/src/lib/sstt/core/components/tuples.ml
+++ b/src/lib/sstt/core/components/tuples.ml
@@ -95,16 +95,16 @@ module MakeC(N:Node) = struct
 
   let dnf (n, bdd) =
     let (export,_,_,_) = dnf_funs n in
-    N.with_own_cache (fun bdd -> Bdd.dnf bdd |> export) bdd
+    Bdd.dnf bdd |> export
   let of_dnf n dnf =
     let (_,import,_,_) = dnf_funs n in
-    N.with_own_cache (fun dnf -> n, import dnf |> Bdd.of_dnf) dnf
+    n, import dnf |> Bdd.of_dnf
   let dnf' (n, bdd) =
     let (_,_,export',_) = dnf_funs n in
-    N.with_own_cache (fun bdd -> Bdd.dnf bdd |> export') bdd
+    Bdd.dnf bdd |> export'
   let of_dnf' n dnf =
     let (_,_,_,import') = dnf_funs n in
-    N.with_own_cache (fun dnf -> n, import' dnf |> Bdd.of_dnf) dnf
+    n, import' dnf |> Bdd.of_dnf
 
   let direct_nodes (_,t) = Bdd.atoms t |> List.concat_map Atom.direct_nodes
   let map_nodes f (tag,t) = tag, Bdd.map_nodes (Atom.map_nodes f) t

--- a/src/lib/sstt/core/core.ml
+++ b/src/lib/sstt/core/core.ml
@@ -66,6 +66,8 @@ module Ty : Ty = struct
   let is_any t = N.with_own_cache N.is_any t
 
   let compare, equal, hash = N.compare, N.equal, N.hash
+
+  let with_shared_cache = N.with_own_cache
 end
 
 (** @canonical Sstt.VDescr *)

--- a/src/lib/sstt/core/core.ml
+++ b/src/lib/sstt/core/core.ml
@@ -67,7 +67,7 @@ module Ty : Ty = struct
 
   let compare, equal, hash = N.compare, N.equal, N.hash
 
-  let with_shared_cache = N.with_own_cache
+  let with_shared_cache = N.with_shared_cache
 end
 
 (** @canonical Sstt.VDescr *)

--- a/src/lib/sstt/core/core.ml
+++ b/src/lib/sstt/core/core.ml
@@ -35,7 +35,7 @@ module Ty : Ty = struct
   module VDescr = Node.VDescr
   module F = VDescr.Descr.Records.FTy
   module O = F.OTy
-  let simpl t = N.with_own_cache N.simplify t ; t
+  let simpl t = N.simplify t ; t
   let s f t = f t |> simpl
   let s' f t = simpl t |> f
 
@@ -57,13 +57,13 @@ module Ty : Ty = struct
   let all_vars, all_vars_toplevel = s' N.all_vars, s' N.all_vars_toplevel
   let of_eqs eqs = N.of_eqs eqs |> List.map (fun (v,ty) -> v, simpl ty)
   let substitute s t = N.substitute s t |> simpl
-  let factorize t = N.with_own_cache N.factorize t |> simpl
+  let factorize t = N.factorize t |> simpl
 
-  let is_empty t = N.with_own_cache N.is_empty t
-  let leq t1 t2 = N.equal t1 t2 || N.with_own_cache (N.leq t1) t2
-  let equiv t1 t2 = N.equal t1 t2 || N.with_own_cache (N.equiv t1) t2
-  let disjoint t1 t2 = N.with_own_cache (N.disjoint t1) t2
-  let is_any t = N.with_own_cache N.is_any t
+  let is_empty t = N.is_empty t
+  let leq t1 t2 = N.equal t1 t2 || (N.leq t1) t2
+  let equiv t1 t2 = N.equal t1 t2 ||(N.equiv t1) t2
+  let disjoint t1 t2 = (N.disjoint t1) t2
+  let is_any t = N.is_any t
 
   let compare, equal, hash = N.compare, N.equal, N.hash
 

--- a/src/lib/sstt/core/core.ml
+++ b/src/lib/sstt/core/core.ml
@@ -35,7 +35,7 @@ module Ty : Ty = struct
   module VDescr = Node.VDescr
   module F = VDescr.Descr.Records.FTy
   module O = F.OTy
-  let simpl t = N.simplify t ; t
+  let simpl t = N.simplify t
   let s f t = f t |> simpl
   let s' f t = simpl t |> f
 
@@ -60,9 +60,9 @@ module Ty : Ty = struct
   let factorize t = N.factorize t |> simpl
 
   let is_empty t = N.is_empty t
-  let leq t1 t2 = N.equal t1 t2 || (N.leq t1) t2
-  let equiv t1 t2 = N.equal t1 t2 ||(N.equiv t1) t2
-  let disjoint t1 t2 = (N.disjoint t1) t2
+  let leq t1 t2 = N.equal t1 t2 || N.leq t1 t2
+  let equiv t1 t2 = N.equal t1 t2 || N.equiv t1 t2
+  let disjoint t1 t2 = N.disjoint t1 t2
   let is_any t = N.is_any t
 
   let compare, equal, hash = N.compare, N.equal, N.hash
@@ -77,7 +77,7 @@ module VDescr = Ty.VDescr
 module Descr = VDescr.Descr
 
 
-(** {2 Components } 
+(** {2 Components }
 
     Components are the building blocks of types. Each component represents a
     union of intersections (a DNF) of a particular "type constructor" (basic

--- a/src/lib/sstt/core/node.ml
+++ b/src/lib/sstt/core/node.ml
@@ -126,26 +126,25 @@ include (struct
     module Table = Bttable.MakeOpt(PreNode)(Bool)
 
 
-    (** The memoization cache. It is indexed by the pair of a VDescr.t 
-        and the flag indicating if this corresponds to a simplified node.
-        Given a node [t], the following invariant should be maintained when
-        memoization is active (i.e. in the context of a [with_shared_cache]).
+    (** The memoization cache. Two caches are kept, one for simplified the other
+          for unsimplified nodes. Given a node [t], the following invariant
+          should be maintained when memoization is active (i.e. in the context
+          of a [with_shared_cache]).
 
-        For every a node [n] that occurs in [t], then if 
-        [(def n, n.simplified)] → [n'] is in the cache, then [n == n'].
+        For every a node [n] that occurs in [t], if [def n] → [n'] is in the
+        cache, then [n == n']. [n'] is calthenled the canonical node for the
+        descriptor [def n].
 
-        This invariant must be enforced by all functions that call [define] below
-        to update the content of a node.
+        A descriptor has at most two canonical nodes, one in each version of the
+        cache.
 
+        This invariant must be enforced by all functions that call [define]
+        below to update the content of a node.
     *)
-    module ConsCache = Hashtbl.Make(struct 
-        type t = VDescr.t * bool 
-        let equal (x1:t) (x2:t) =
-          x1 == x2 ||
-          let t1, b1 = x1 and t2, b2 = x2 in
-          b1 = b2 && VDescr.equal t1 t2
-        let hash (t, b) = Hash.(mix (VDescr.hash t) (int_of_bool b))
-      end)
+
+    module ConsCache = Hashtbl.Make(VDescr)
+
+    (** Cache for set-theoretic operations *)
 
     module BinOpCache = Hashtbl.Make(struct
         type t = PreNode.t * PreNode.t
@@ -154,7 +153,7 @@ include (struct
       )
 
     type cache = { is_empty_cache : Table.t;
-                   cons_cache : PreNode.t ConsCache.t;
+                   cons_cache : PreNode.t ConsCache.t * PreNode.t ConsCache.t;
                    inter_cache : PreNode.t BinOpCache.t;
                    union_cache : PreNode.t BinOpCache.t;
                    diff_cache : PreNode.t BinOpCache.t }
@@ -162,23 +161,29 @@ include (struct
     type _ Effect.t += GetCache: cache t
 
     let create_cache () =
-      let cons_cache = ConsCache.create 16 in
-      ConsCache.add cons_cache (VDescr.empty,true) AnyEmpty.empty;
-      ConsCache.add cons_cache (VDescr.any,true) AnyEmpty.any;
+      let sim_cons_cache = ConsCache.create 4 in
+      ConsCache.add sim_cons_cache VDescr.empty AnyEmpty.empty;
+      ConsCache.add sim_cons_cache VDescr.any AnyEmpty.any;
 
       { is_empty_cache = Table.create ();
-        cons_cache ; 
-        inter_cache = BinOpCache.create 16;
-        union_cache = BinOpCache.create 16;
-        diff_cache = BinOpCache.create 16 }
+        cons_cache = sim_cons_cache, ConsCache.create 4;
+        inter_cache = BinOpCache.create 4;
+        union_cache = BinOpCache.create 4;
+        diff_cache = BinOpCache.create 4 }
 
     let[@inline always] get_cache () = perform GetCache
     let[@inline always] get_is_empty_cache () = (get_cache ()).is_empty_cache
-    let[@inline always] get_cons_cache () = (get_cache()).cons_cache
+    let[@inline always] get_cons_cache b =
+      let c1, c2 = (get_cache()).cons_cache in
+      if b then c1 else c2
     let[@inline always] get_inter_cache () = (get_cache()).inter_cache
     let[@inline always] get_union_cache () = (get_cache()).union_cache
     let[@inline always] get_diff_cache () = (get_cache()).diff_cache
 
+
+    (* with_shared_cache is made re-entrant by looking for the top-most cache
+       on the call stack, if any.
+    *)
     let with_shared_cache f t =
       let cache : cache option ref = ref None in
       try f t with
@@ -231,13 +236,12 @@ include (struct
       else if VDescr.(equal d any) then any
       else
         try
-          let cache = get_cons_cache () in
-          let k = d, simplified in
-          match ConsCache.find_opt cache k with
-            Some t -> t
+          let cache = get_cons_cache simplified in
+          match ConsCache.find_opt cache d with
+            Some t -> t (* returns the canonical node *)
           | None ->
             let t = mk () in
-            ConsCache.add cache k t;
+            ConsCache.add cache d t; (* sets t as the canonical node *)
             define ~simplified t d ; t
         with
           Unhandled GetCache ->
@@ -284,6 +288,16 @@ include (struct
     let conj ts = List.fold_left cap any ts
     let disj ts = List.fold_left cup empty ts
 
+    (** Entry point of the subtyping algorithm. The fast path is done outside of
+        the scope of with_shared_cache so that a toplevel call to `is_empty`
+        returns quickly if the result is trivial.
+
+      Any function in this module which calls directly or indirectly the
+      subtyping algorithm can be guarded by [with_shared_cache] to share the
+      subtyping cache among all its calls.
+        *)
+
+
     let is_empty_rec t =
       let cache = get_is_empty_cache () in
       begin match Table.find ~default:true cache t with
@@ -302,6 +316,7 @@ include (struct
       else if t.simplified then VDescr.equal (def t) VDescr.empty
       else is_empty_rec t
 
+    (* Derived subtyping function *)
     let leq t1 t2 = diff t1 t2 |> is_empty
 
     let equiv t1 t2 = leq t1 t2 && leq t2 t1
@@ -310,22 +325,26 @@ include (struct
     let is_any t = neg t |> is_empty
     let disjoint t1 t2 = cap t1 t2 |> is_empty
 
+
+    (* Node simplification we recursively traverse the node and simplify it. For
+       each vdescr encountered we ensure that its surrounding node is the
+       canonical one, if it exists in the cache, otherwise we can leave it. *)
+
     let rec simplify_rec t =
       if t.simplified then t
       else
         let t_def = def t in
-        let cache = get_cons_cache () in
-        match ConsCache.find_opt cache (t_def,true) with
+        let cache = get_cons_cache true in
+        match ConsCache.find_opt cache t_def with
           Some t' -> t' (* a simplified t exists in the cache, return it *)
         | None ->
           t.simplified <- true; (* to stop the recursion when we encounter t again *)
           let s_def = t_def |> VDescr.simplify |> VDescr.map_nodes simplify_rec in
-          let k = s_def, true in
-          match ConsCache.find_opt cache k with
-            Some t' -> t.simplified <- false; t' (* the simplified descriptor is already memoized,
-                                                    return it without updating t, as t itself has not been
+          match ConsCache.find_opt cache s_def with
+            Some t' -> t.simplified <- false; t' (* the simplified descriptor alread has a canonical node,
+                                                    return it and resets t.simplified as t itself has not been
                                                     simplified (but replaced by t') *)
-          | None ->
+          | None -> (* No canonical node is found, update in place *)
             define ~simplified:true t s_def;
             t
 
@@ -356,13 +375,15 @@ include (struct
       NSet.fold (fun n -> VarSet.union (vars_toplevel n)) (dependencies t) VarSet.empty
     let row_vars t =
       NSet.fold (fun n -> RowVarSet.union (row_vars_toplevel n)) (dependencies t) RowVarSet.empty
-    let all_vars t = 
+    let all_vars t =
       match t.all_vars with
         Some s -> s
       | None ->
         let s = MixVarSet.of_set (vars t) (row_vars t) in
         t.all_vars <- Some s; s
 
+
+    (** Systems of contractive equations. [simplify] above must be called on the result (done in Core) *)
     let of_eqs eqs =
       let deps = eqs
         |> List.fold_left (fun acc (_, t) -> NSet.union (dependencies t) acc) NSet.empty in
@@ -400,6 +421,7 @@ include (struct
       define_all deps ;
       eqs |> List.map (fun (v,n) -> v,new_node n)
 
+    (** Variable substitution. [simplify] above must be called on the result (done in Core) *)
     let substitute s t =
       if MixVarMap.is_empty s then t else
         let dom = MixVarMap.fold
@@ -423,6 +445,7 @@ include (struct
           ) ;
         new_node t
 
+    (** Common node factorization. [simplify] above must be called on the result (done in Core) *)
     let factorize t =
       let cache = NH.create 10 in
       let nodes = ref [] in

--- a/src/lib/sstt/core/node.ml
+++ b/src/lib/sstt/core/node.ml
@@ -221,9 +221,12 @@ include (struct
 
     let define ?(simplified=false) t d =
       (* Clear the cached fields *)
+      let () = match t.neg with
+          None -> ()
+        | Some n -> n.neg <- None; t.neg <- None
+      in
       t.dependencies <- None ;
       t.all_vars <- None;
-      t.neg <- None ;
 
       t.def <- Some d ;
       t.simplified <- simplified
@@ -292,10 +295,10 @@ include (struct
         the scope of with_shared_cache so that a toplevel call to `is_empty`
         returns quickly if the result is trivial.
 
-      Any function in this module which calls directly or indirectly the
-      subtyping algorithm can be guarded by [with_shared_cache] to share the
-      subtyping cache among all its calls.
-        *)
+        Any function in this module which calls directly or indirectly the
+        subtyping algorithm can be guarded by [with_shared_cache] to share the
+        subtyping cache among all its calls.
+    *)
 
 
     let is_empty_rec t =
@@ -340,13 +343,11 @@ include (struct
         | None ->
           t.simplified <- true; (* to stop the recursion when we encounter t again *)
           let s_def = t_def |> VDescr.simplify |> VDescr.map_nodes simplify_rec in
+          define ~simplified:true t s_def;
           match ConsCache.find_opt cache s_def with
-            Some t' -> t.simplified <- false; t' (* the simplified descriptor alread has a canonical node,
-                                                    return it and resets t.simplified as t itself has not been
-                                                    simplified (but replaced by t') *)
-          | None -> (* No canonical node is found, update in place *)
-            define ~simplified:true t s_def;
-            t
+            Some t' -> t' (* the simplified descriptor alread has a canonical node *)
+          | None -> t (* No canonical node t was updated in place *)
+
 
     let simplify_rec = with_shared_cache simplify_rec
     let simplify t = if t.simplified then t else simplify_rec t

--- a/src/lib/sstt/core/node.ml
+++ b/src/lib/sstt/core/node.ml
@@ -120,10 +120,17 @@ include (struct
                          and type row = VDescr.Descr.Records.Atom.t = struct
     (* The PreNode module that contain the entry points of all functions on types. *)
     module NH = Hashtbl.Make(PreNode)
-    module Table = Bttable.MakeOpt(VDescr)(Bool)
+    module Table = Bttable.MakeOpt(PreNode)(Bool)
+    module ConsCache = Hashtbl.Make(VDescr)
 
-    type cache = { is_empty_cache : Table.t }
+    type cache = { is_empty_cache : Table.t;
+                   cons_cache : PreNode.t ConsCache.t }
+
     type _ Effect.t += GetCache: cache t
+
+    let get_cache () = perform GetCache
+    let get_is_empty_cache () = (get_cache ()).is_empty_cache
+    let get_cons_cache () = (get_cache()).cons_cache
 
     type vdescr = VDescr.t
     type descr = VDescr.Descr.t
@@ -148,12 +155,24 @@ include (struct
       t.dependencies <- None ;
       t.simplified <- simplified
 
+    (* If a handler for the GetCache effect is in place,
+       memoize the node. Otherwise just create a fresh node.
+    *)
     let cons ?(simplified=false) d =
       if VDescr.(equal d empty) then empty
       else if VDescr.(equal d any) then any
       else
-        let t = mk () in
-        define ~simplified t d ; t
+        try
+          let cache = get_cons_cache () in
+          match ConsCache.find_opt cache d with
+            Some t -> t
+          | None ->
+            let t = mk () in
+            ConsCache.add cache d t;
+            define ~simplified t d ; t
+        with
+          Unhandled GetCache ->
+          let t = mk () in define ~simplified t d; t
 
     let of_def d = d |> cons
 
@@ -180,29 +199,33 @@ include (struct
     let conj ts = List.fold_left cap any ts
     let disj ts = List.fold_left cup empty ts
 
-    let get_cache () = perform GetCache
-
     let with_own_cache f t =
       let cache : cache option ref = ref None in
       try f t with
       | effect GetCache, k ->
         match !cache with
-          Some c -> continue k c
-        | None -> let c = { is_empty_cache = Table.create () } in
-          cache := Some c;
+          Some c -> continue k c (* the topmost cache has already been found *)
+        | None ->
+          (* Otherwise, we perform the effect again, to reach the topmost call to with_own_cache *)
+          let c = try perform GetCache with Unhandled GetCache ->
+
+            (* no handler above us, create the cache *)
+            { is_empty_cache = Table.create ();
+              cons_cache = ConsCache.create 16 }
+          in
+          cache := Some c; (* store the returned cache *)
           continue k c
 
     let is_empty t =
-      let def = def t in
       if t.simplified then
-        VDescr.equal def VDescr.empty
+        VDescr.equal (def t) VDescr.empty
       else
-        let { is_empty_cache; _ } = get_cache () in
-        begin match Table.find ~default:true is_empty_cache def with
+        let cache = get_is_empty_cache () in
+        begin match Table.find ~default:true cache t with
           | Some b -> b
           | None ->
-            let b = VDescr.is_empty def in
-            Table.update is_empty_cache def b;
+            let b = VDescr.is_empty (def t) in
+            Table.update cache t b;
             b
         end
 

--- a/src/lib/sstt/core/node.ml
+++ b/src/lib/sstt/core/node.ml
@@ -84,9 +84,9 @@ include (struct
         dependencies = None;
         neg = None;
       }
-    let hash t = Hash.int t.id
+    let hash t = t.id
     let compare t1 t2 = Int.compare t1.id t2.id
-    let equal t1 t2 = Int.equal t1.id t2.id
+    let equal t1 t2 = t1 == t2
     let empty = mk ()
     let any = mk ()
 
@@ -121,7 +121,9 @@ include (struct
     (* The PreNode module that contain the entry points of all functions on types. *)
     module NH = Hashtbl.Make(PreNode)
     module Table = Bttable.MakeOpt(VDescr)(Bool)
-    type _ Effect.t += GetCache: (Table.t) t
+
+    type cache = { is_empty_cache : Table.t }
+    type _ Effect.t += GetCache: cache t
 
     type vdescr = VDescr.t
     type descr = VDescr.Descr.t
@@ -145,9 +147,13 @@ include (struct
       t.def <- Some d ;
       t.dependencies <- None ;
       t.simplified <- simplified
+
     let cons ?(simplified=false) d =
-      let t = mk () in
-      define ~simplified t d ; t
+      if VDescr.(equal d empty) then empty
+      else if VDescr.(equal d any) then any
+      else
+        let t = mk () in
+        define ~simplified t d ; t
 
     let of_def d = d |> cons
 
@@ -175,23 +181,28 @@ include (struct
     let disj ts = List.fold_left cup empty ts
 
     let get_cache () = perform GetCache
+
     let with_own_cache f t =
-      let cache = Table.create () in
-      match f t with
-        x -> x
-      | effect GetCache, k -> continue k cache
+      let cache : cache option ref = ref None in
+      try f t with
+      | effect GetCache, k ->
+        match !cache with
+          Some c -> continue k c
+        | None -> let c = { is_empty_cache = Table.create () } in
+          cache := Some c;
+          continue k c
 
     let is_empty t =
       let def = def t in
       if t.simplified then
         VDescr.equal def VDescr.empty
       else
-        let cache = get_cache () in
-        begin match Table.find ~default:true cache def with
+        let { is_empty_cache; _ } = get_cache () in
+        begin match Table.find ~default:true is_empty_cache def with
           | Some b -> b
           | None ->
             let b = VDescr.is_empty def in
-            Table.update cache def b;
+            Table.update is_empty_cache def b;
             b
         end
 

--- a/src/lib/sstt/core/node.ml
+++ b/src/lib/sstt/core/node.ml
@@ -175,7 +175,9 @@ include (struct
         try
           let cache = get_cons_cache () in
           match ConsCache.find_opt cache d with
-            Some t -> t
+            Some t ->
+            if not t.simplified && simplified then t.simplified <- true;
+            t
           | None ->
             let t = mk () in
             ConsCache.add cache d t;
@@ -245,40 +247,43 @@ include (struct
           cache := Some c; (* store the returned cache *)
           continue k c
 
-    let is_empty t =
-      if t.simplified then
-        VDescr.equal (def t) VDescr.empty
-      else
-        let cache = get_is_empty_cache () in
-        begin match Table.find ~default:true cache t with
-          | Some b -> b
-          | None ->
-            let b = VDescr.is_empty (def t) in
-            Table.update cache t b;
-            b
-        end
+    let is_empty_rec t =
+      let cache = get_is_empty_cache () in
+      begin match Table.find ~default:true cache t with
+        | Some b -> b
+        | None ->
+          let b = VDescr.is_empty (def t) in
+          Table.update cache t b;
+          b
+      end
 
-    let is_empty = with_shared_cache is_empty
+    let is_empty_rec = with_shared_cache is_empty_rec
+
+    let is_empty t =
+      if t == empty then true
+      else if t == any then false
+      else if t.simplified then VDescr.equal (def t) VDescr.empty
+      else is_empty_rec t
 
     let leq t1 t2 = diff t1 t2 |> is_empty
-    let equiv t1 t2 = leq t1 t2 && leq t2 t1
 
+    let equiv t1 t2 = leq t1 t2 && leq t2 t1
     let equiv = with_shared_cache equiv
 
     let is_any t = neg t |> is_empty
     let disjoint t1 t2 = cap t1 t2 |> is_empty
 
-    let rec simplify t =
-      if not t.simplified then begin
-        let s_def = def t |> VDescr.simplify in
-        define ~simplified:true t s_def;
-        s_def |> VDescr.direct_nodes |> List.iter simplify;
-        match t.neg with
-          None -> ()
-        | Some nt -> define ~simplified:true nt (VDescr.neg s_def);
-      end
+    let rec simplify_rec t =
+      let s_def = def t |> VDescr.simplify in
+      define ~simplified:true t s_def;
+      s_def |> VDescr.direct_nodes |> List.iter simplify_aux;
+      match t.neg with
+        None -> ()
+      | Some nt -> define ~simplified:true nt (VDescr.neg s_def)
+    and simplify_aux t = if not t.simplified then simplify_rec t
 
-    let simplify = with_shared_cache simplify
+    let simplify_rec = with_shared_cache simplify_rec
+    let simplify t = if not t.simplified then simplify_rec t
 
     let dependencies t =
       let direct_nodes t = def t |> VDescr.direct_nodes |> NSet.of_list in

--- a/src/lib/sstt/core/node.ml
+++ b/src/lib/sstt/core/node.ml
@@ -121,8 +121,32 @@ include (struct
   and PreNode : PreNode with type t = AnyEmpty.t and type vdescr = VDescr.t and type descr = VDescr.Descr.t
                                                                             and type row = VDescr.Descr.Records.Atom.t = struct
     (* The PreNode module that contain the entry points of all functions on types. *)
+
+    (* Subtyping cache *)
     module Table = Bttable.MakeOpt(PreNode)(Bool)
-    module ConsCache = Hashtbl.Make(VDescr)
+
+
+    (** The memoization cache. It is indexed by the pair of a VDescr.t 
+        and the flag indicating if this corresponds to a simplified node.
+        Given a node [t], the following invariant should be maintained when
+        memoization is active (i.e. in the context of a [with_shared_cache]).
+
+        For every a node [n] that occurs in [t], then if 
+        [(def n, n.simplified)] → [n'] is in the cache, then [n == n'].
+
+        This invariant must be enforced by all functions that call [define] below
+        to update the content of a node.
+
+    *)
+    module ConsCache = Hashtbl.Make(struct 
+        type t = VDescr.t * bool 
+        let equal (x1:t) (x2:t) =
+          x1 == x2 ||
+          let t1, b1 = x1 and t2, b2 = x2 in
+          b1 = b2 && VDescr.equal t1 t2
+        let hash (t, b) = Hash.(mix (VDescr.hash t) (int_of_bool b))
+      end)
+
     module BinOpCache = Hashtbl.Make(struct
         type t = PreNode.t * PreNode.t
         let equal (t1, t2) (s1, s2) = PreNode.equal t1 s1 && PreNode.equal t2 s2
@@ -138,8 +162,12 @@ include (struct
     type _ Effect.t += GetCache: cache t
 
     let create_cache () =
+      let cons_cache = ConsCache.create 16 in
+      ConsCache.add cons_cache (VDescr.empty,true) AnyEmpty.empty;
+      ConsCache.add cons_cache (VDescr.any,true) AnyEmpty.any;
+
       { is_empty_cache = Table.create ();
-        cons_cache = ConsCache.create 16;
+        cons_cache ; 
         inter_cache = BinOpCache.create 16;
         union_cache = BinOpCache.create 16;
         diff_cache = BinOpCache.create 16 }
@@ -187,8 +215,12 @@ include (struct
     let equal = AnyEmpty.equal
 
     let define ?(simplified=false) t d =
-      t.def <- Some d ;
+      (* Clear the cached fields *)
       t.dependencies <- None ;
+      t.all_vars <- None;
+      t.neg <- None ;
+
+      t.def <- Some d ;
       t.simplified <- simplified
 
     (* If a handler for the GetCache effect is in place,
@@ -200,13 +232,12 @@ include (struct
       else
         try
           let cache = get_cons_cache () in
-          match ConsCache.find_opt cache d with
-            Some t ->
-            if not t.simplified && simplified then t.simplified <- true;
-            t
+          let k = d, simplified in
+          match ConsCache.find_opt cache k with
+            Some t -> t
           | None ->
             let t = mk () in
-            ConsCache.add cache d t;
+            ConsCache.add cache k t;
             define ~simplified t d ; t
         with
           Unhandled GetCache ->
@@ -240,7 +271,7 @@ include (struct
       | Some s -> s
       | None ->
         let s = t |> def |> VDescr.neg
-                |> cons ~simplified:t.simplified in
+          |> cons ~simplified:t.simplified in
         t.neg <- Some s;
         s.neg <- Some t;
         s
@@ -280,26 +311,34 @@ include (struct
     let disjoint t1 t2 = cap t1 t2 |> is_empty
 
     let rec simplify_rec t =
-      let s_def = def t |> VDescr.simplify in
-      define ~simplified:true t s_def;
-      s_def |> VDescr.direct_nodes |> List.iter simplify_aux;
-      t.dependencies <- None;
-      t.all_vars <- None;
-      match t.neg with
-        None -> ()
-      | Some nt -> define ~simplified:true nt (VDescr.neg s_def)
-    and simplify_aux t = if not t.simplified then simplify_rec t
+      if t.simplified then t
+      else
+        let t_def = def t in
+        let cache = get_cons_cache () in
+        match ConsCache.find_opt cache (t_def,true) with
+          Some t' -> t' (* a simplified t exists in the cache, return it *)
+        | None ->
+          t.simplified <- true; (* to stop the recursion when we encounter t again *)
+          let s_def = t_def |> VDescr.simplify |> VDescr.map_nodes simplify_rec in
+          let k = s_def, true in
+          match ConsCache.find_opt cache k with
+            Some t' -> t.simplified <- false; t' (* the simplified descriptor is already memoized,
+                                                    return it without updating t, as t itself has not been
+                                                    simplified (but replaced by t') *)
+          | None ->
+            define ~simplified:true t s_def;
+            t
 
     let simplify_rec = with_shared_cache simplify_rec
-    let simplify t = if not t.simplified then simplify_rec t
+    let simplify t = if t.simplified then t else simplify_rec t
 
     let dependencies t =
       let direct_nodes t = def t |> VDescr.direct_nodes |> NSet.of_list in
       let rec aux ts =
         let ts' = ts
-                  |> NSet.to_list
-                  |> List.map direct_nodes
-                  |> List.fold_left NSet.union ts
+          |> NSet.to_list
+          |> List.map direct_nodes
+          |> List.fold_left NSet.union ts
         in
         if NSet.equal ts ts' then ts' else aux ts'
       in
@@ -319,14 +358,14 @@ include (struct
       NSet.fold (fun n -> RowVarSet.union (row_vars_toplevel n)) (dependencies t) RowVarSet.empty
     let all_vars t = 
       match t.all_vars with
-       Some s -> s
-       | None ->
+        Some s -> s
+      | None ->
         let s = MixVarSet.of_set (vars t) (row_vars t) in
         t.all_vars <- Some s; s
 
     let of_eqs eqs =
       let deps = eqs
-                 |> List.fold_left (fun acc (_, t) -> NSet.union (dependencies t) acc) NSet.empty in
+        |> List.fold_left (fun acc (_, t) -> NSet.union (dependencies t) acc) NSet.empty in
       let copies = NH.create 10 in
       let () = NSet.iter (fun n -> NH.add copies n (mk ())) deps in
       let new_node n =
@@ -353,7 +392,7 @@ include (struct
                   if has_def nn then Some (v, def nn) else None
                 ) in
               let d = def n |> VDescr.map_nodes new_node
-                      |> VDescr.substitute (MixVarMap.of_list1 s) in
+                |> VDescr.substitute (MixVarMap.of_list1 s) in
               define nn d
             end ;
             define_all (NSet.remove n deps)

--- a/src/lib/sstt/core/node.ml
+++ b/src/lib/sstt/core/node.ml
@@ -229,8 +229,13 @@ include (struct
             b
         end
 
+    let is_empty = with_own_cache is_empty
+
     let leq t1 t2 = diff t1 t2 |> is_empty
     let equiv t1 t2 = leq t1 t2 && leq t2 t1
+
+    let equiv = with_own_cache equiv
+
     let is_any t = neg t |> is_empty
     let disjoint t1 t2 = cap t1 t2 |> is_empty
 
@@ -243,6 +248,8 @@ include (struct
           None -> ()
         | Some nt -> define ~simplified:true nt (VDescr.neg s_def);
       end
+
+    let simplify = with_own_cache simplify
 
     let dependencies t =
       let direct_nodes t = def t |> VDescr.direct_nodes |> NSet.of_list in
@@ -351,6 +358,8 @@ include (struct
           end
       in
       aux t
+
+    let factorize = with_own_cache factorize
 
     let mk_var v = VDescr.mk_var v |> cons
     let mk_descr d = VDescr.mk_descr d |> cons

--- a/src/lib/sstt/core/node.ml
+++ b/src/lib/sstt/core/node.ml
@@ -122,15 +122,25 @@ include (struct
     module NH = Hashtbl.Make(PreNode)
     module Table = Bttable.MakeOpt(PreNode)(Bool)
     module ConsCache = Hashtbl.Make(VDescr)
-
+    module BinOpCache = Hashtbl.Make(struct
+        type t = PreNode.t * PreNode.t
+        let equal (t1, t2) (s1, s2) = PreNode.equal t1 s1 && PreNode.equal t2 s2
+        let hash (t1, t2) = Hash.mix (PreNode.hash t1) (PreNode.hash t2) end
+      )
     type cache = { is_empty_cache : Table.t;
-                   cons_cache : PreNode.t ConsCache.t }
+                   cons_cache : PreNode.t ConsCache.t;
+                   inter_cache : PreNode.t BinOpCache.t;
+                   union_cache : PreNode.t BinOpCache.t;
+                   diff_cache : PreNode.t BinOpCache.t }
 
     type _ Effect.t += GetCache: cache t
 
-    let get_cache () = perform GetCache
-    let get_is_empty_cache () = (get_cache ()).is_empty_cache
-    let get_cons_cache () = (get_cache()).cons_cache
+    let[@inline always] get_cache () = perform GetCache
+    let[@inline always] get_is_empty_cache () = (get_cache ()).is_empty_cache
+    let[@inline always] get_cons_cache () = (get_cache()).cons_cache
+    let[@inline always] get_inter_cache () = (get_cache()).inter_cache
+    let[@inline always] get_union_cache () = (get_cache()).union_cache
+    let[@inline always] get_diff_cache () = (get_cache()).diff_cache
 
     type vdescr = VDescr.t
     type descr = VDescr.Descr.t
@@ -176,10 +186,25 @@ include (struct
 
     let of_def d = d |> cons
 
+    let binop op get t1 t2 =
+      try
+        let cache = get () in
+        let key = t1, t2 in
+        match BinOpCache.find_opt cache key with
+          Some t -> t
+        | None ->
+          let t = op t1 t2 in
+          BinOpCache.add cache key t;
+          t
+      with Unhandled GetCache -> op t1 t2
+
+
     let dcap t1 t2 = VDescr.cap (def t1) (def t2) |> cons
+    let dcap = binop dcap get_inter_cache
     let cap = fcap ~empty ~any ~cap:dcap
 
     let dcup t1 t2 = VDescr.cup (def t1) (def t2) |> cons
+    let dcup = binop dcup get_union_cache
     let cup = fcup ~empty ~any ~cup:dcup
 
     let neg t =
@@ -194,24 +219,28 @@ include (struct
     let neg = fneg ~empty ~any ~neg
 
     let fdiff t1 t2 = VDescr.diff (def t1) (def t2) |> cons
+    let fdiff = binop fdiff get_diff_cache
     let diff = fdiff_neg ~empty ~any ~neg ~diff:fdiff
 
     let conj ts = List.fold_left cap any ts
     let disj ts = List.fold_left cup empty ts
 
-    let with_own_cache f t =
+    let with_shared_cache f t =
       let cache : cache option ref = ref None in
       try f t with
       | effect GetCache, k ->
         match !cache with
           Some c -> continue k c (* the topmost cache has already been found *)
         | None ->
-          (* Otherwise, we perform the effect again, to reach the topmost call to with_own_cache *)
-          let c = try perform GetCache with Unhandled GetCache ->
+          (* Otherwise, we perform the effect again, to reach the topmost call to with_shared_cache *)
+          let c = try get_cache () with Unhandled GetCache ->
 
             (* no handler above us, create the cache *)
             { is_empty_cache = Table.create ();
-              cons_cache = ConsCache.create 16 }
+              cons_cache = ConsCache.create 16;
+              inter_cache = BinOpCache.create 16;
+              union_cache = BinOpCache.create 16;
+              diff_cache = BinOpCache.create 16 }
           in
           cache := Some c; (* store the returned cache *)
           continue k c
@@ -229,12 +258,12 @@ include (struct
             b
         end
 
-    let is_empty = with_own_cache is_empty
+    let is_empty = with_shared_cache is_empty
 
     let leq t1 t2 = diff t1 t2 |> is_empty
     let equiv t1 t2 = leq t1 t2 && leq t2 t1
 
-    let equiv = with_own_cache equiv
+    let equiv = with_shared_cache equiv
 
     let is_any t = neg t |> is_empty
     let disjoint t1 t2 = cap t1 t2 |> is_empty
@@ -249,7 +278,7 @@ include (struct
         | Some nt -> define ~simplified:true nt (VDescr.neg s_def);
       end
 
-    let simplify = with_own_cache simplify
+    let simplify = with_shared_cache simplify
 
     let dependencies t =
       let direct_nodes t = def t |> VDescr.direct_nodes |> NSet.of_list in
@@ -359,7 +388,7 @@ include (struct
       in
       aux t
 
-    let factorize = with_own_cache factorize
+    let factorize = with_shared_cache factorize
 
     let mk_var v = VDescr.mk_var v |> cons
     let mk_descr d = VDescr.mk_descr d |> cons

--- a/src/lib/sstt/core/node.ml
+++ b/src/lib/sstt/core/node.ml
@@ -56,6 +56,7 @@ include (struct
       mutable def : VDescr.t option ;
       mutable simplified : bool ;
       mutable dependencies : NSet.t option;
+      mutable all_vars : MixVarSet.t option;
       mutable neg : t option
     }
   end = TyRef (* Trick: a recursive module with only types can be its own definition *)
@@ -82,6 +83,7 @@ include (struct
         def = None ;
         simplified = false ;
         dependencies = None;
+        all_vars = None;
         neg = None;
       }
     let hash t = t.id
@@ -103,7 +105,7 @@ include (struct
       any.dependencies <- Some (NSet.singleton any)
   end
   and Node : Node with type t = AnyEmpty.t and type vdescr = VDescr.t and type descr = VDescr.Descr.t
-                   and type row = VDescr.Descr.Records.Atom.t = struct
+                                                                      and type row = VDescr.Descr.Records.Atom.t = struct
     (* The module which contains any and empty that is passed to Vdescr.Make *)
     include PreNode
     (* We need to duplicate these here, has the one in PreNode are uninitialized  *)
@@ -117,9 +119,8 @@ include (struct
   and NSet : Set.S with type elt = AnyEmpty.t = Set.Make(PreNode) (* Sets of Node.t, but use PreNode to have a well defined cycle *)
   and VDescr : VDescr' with type node = Node.t = Vdescr.Make(Node) (* Instanciate VDescr *)
   and PreNode : PreNode with type t = AnyEmpty.t and type vdescr = VDescr.t and type descr = VDescr.Descr.t
-                         and type row = VDescr.Descr.Records.Atom.t = struct
+                                                                            and type row = VDescr.Descr.Records.Atom.t = struct
     (* The PreNode module that contain the entry points of all functions on types. *)
-    module NH = Hashtbl.Make(PreNode)
     module Table = Bttable.MakeOpt(PreNode)(Bool)
     module ConsCache = Hashtbl.Make(VDescr)
     module BinOpCache = Hashtbl.Make(struct
@@ -127,6 +128,7 @@ include (struct
         let equal (t1, t2) (s1, s2) = PreNode.equal t1 s1 && PreNode.equal t2 s2
         let hash (t1, t2) = Hash.mix (PreNode.hash t1) (PreNode.hash t2) end
       )
+
     type cache = { is_empty_cache : Table.t;
                    cons_cache : PreNode.t ConsCache.t;
                    inter_cache : PreNode.t BinOpCache.t;
@@ -135,12 +137,36 @@ include (struct
 
     type _ Effect.t += GetCache: cache t
 
+    let create_cache () =
+      { is_empty_cache = Table.create ();
+        cons_cache = ConsCache.create 16;
+        inter_cache = BinOpCache.create 16;
+        union_cache = BinOpCache.create 16;
+        diff_cache = BinOpCache.create 16 }
+
     let[@inline always] get_cache () = perform GetCache
     let[@inline always] get_is_empty_cache () = (get_cache ()).is_empty_cache
     let[@inline always] get_cons_cache () = (get_cache()).cons_cache
     let[@inline always] get_inter_cache () = (get_cache()).inter_cache
     let[@inline always] get_union_cache () = (get_cache()).union_cache
     let[@inline always] get_diff_cache () = (get_cache()).diff_cache
+
+    let with_shared_cache f t =
+      let cache : cache option ref = ref None in
+      try f t with
+      | effect GetCache, k ->
+        match !cache with
+          Some c -> continue k c (* the topmost cache has already been found *)
+        | None ->
+          (* Otherwise, we perform the effect again, to reach the topmost call to with_shared_cache *)
+          let c = try get_cache () with Unhandled GetCache ->
+            (* no handler above us, create the cache *)
+            create_cache ()
+          in
+          cache := Some c; (* store the returned cache *)
+          continue k c
+
+    module NH = Hashtbl.Make(PreNode)
 
     type vdescr = VDescr.t
     type descr = VDescr.Descr.t
@@ -227,26 +253,6 @@ include (struct
     let conj ts = List.fold_left cap any ts
     let disj ts = List.fold_left cup empty ts
 
-    let with_shared_cache f t =
-      let cache : cache option ref = ref None in
-      try f t with
-      | effect GetCache, k ->
-        match !cache with
-          Some c -> continue k c (* the topmost cache has already been found *)
-        | None ->
-          (* Otherwise, we perform the effect again, to reach the topmost call to with_shared_cache *)
-          let c = try get_cache () with Unhandled GetCache ->
-
-            (* no handler above us, create the cache *)
-            { is_empty_cache = Table.create ();
-              cons_cache = ConsCache.create 16;
-              inter_cache = BinOpCache.create 16;
-              union_cache = BinOpCache.create 16;
-              diff_cache = BinOpCache.create 16 }
-          in
-          cache := Some c; (* store the returned cache *)
-          continue k c
-
     let is_empty_rec t =
       let cache = get_is_empty_cache () in
       begin match Table.find ~default:true cache t with
@@ -277,6 +283,8 @@ include (struct
       let s_def = def t |> VDescr.simplify in
       define ~simplified:true t s_def;
       s_def |> VDescr.direct_nodes |> List.iter simplify_aux;
+      t.dependencies <- None;
+      t.all_vars <- None;
       match t.neg with
         None -> ()
       | Some nt -> define ~simplified:true nt (VDescr.neg s_def)
@@ -309,7 +317,12 @@ include (struct
       NSet.fold (fun n -> VarSet.union (vars_toplevel n)) (dependencies t) VarSet.empty
     let row_vars t =
       NSet.fold (fun n -> RowVarSet.union (row_vars_toplevel n)) (dependencies t) RowVarSet.empty
-    let all_vars t = MixVarSet.of_set (vars t) (row_vars t)
+    let all_vars t = 
+      match t.all_vars with
+       Some s -> s
+       | None ->
+        let s = MixVarSet.of_set (vars t) (row_vars t) in
+        t.all_vars <- Some s; s
 
     let of_eqs eqs =
       let deps = eqs
@@ -340,7 +353,7 @@ include (struct
                   if has_def nn then Some (v, def nn) else None
                 ) in
               let d = def n |> VDescr.map_nodes new_node
-              |> VDescr.substitute (MixVarMap.of_list1 s) in
+                      |> VDescr.substitute (MixVarMap.of_list1 s) in
               define nn d
             end ;
             define_all (NSet.remove n deps)
@@ -350,26 +363,26 @@ include (struct
 
     let substitute s t =
       if MixVarMap.is_empty s then t else
-      let dom = MixVarMap.fold
-        (fun n _ -> MixVarSet.add1 n)
-        (fun r _ -> MixVarSet.add2 r)
-          s MixVarSet.empty in
-      let s = s |> MixVarMap.map1 (fun n -> def n) in
-      (* Optimisation: reuse nodes if possible *)
-      let unchanged n = MixVarSet.disjoint (all_vars n) dom in
-      let deps = dependencies t |> NSet.filter (fun n -> unchanged n |> not) in
-      let copies = NH.create 10 in
-      let () = NSet.iter (fun n -> NH.add copies n (mk ())) deps in
-      let new_node n =
-        match NH.find_opt copies n with
-        | Some n -> n
-        | None -> n
-      in
-      deps |> NSet.iter (fun n ->
-          let d = def n |> VDescr.map_nodes new_node |> VDescr.substitute s in
-          define (new_node n) d
-        ) ;
-      new_node t
+        let dom = MixVarMap.fold
+            (fun n _ -> MixVarSet.add1 n)
+            (fun r _ -> MixVarSet.add2 r)
+            s MixVarSet.empty in
+        let s = s |> MixVarMap.map1 (fun n -> def n) in
+        (* Optimisation: reuse nodes if possible *)
+        let unchanged n = MixVarSet.disjoint (all_vars n) dom in
+        let deps = dependencies t |> NSet.filter (fun n -> unchanged n |> not) in
+        let copies = NH.create 10 in
+        let () = NSet.iter (fun n -> NH.add copies n (mk ())) deps in
+        let new_node n =
+          match NH.find_opt copies n with
+          | Some n -> n
+          | None -> n
+        in
+        deps |> NSet.iter (fun n ->
+            let d = def n |> VDescr.map_nodes new_node |> VDescr.substitute s in
+            define (new_node n) d
+          ) ;
+        new_node t
 
     let factorize t =
       let cache = NH.create 10 in
@@ -405,6 +418,6 @@ include (struct
 
 end : sig (* Hide everything, we could also add that in a .mli file. *)
            module rec Node : (Node with type vdescr = VDescr.t and type descr = VDescr.Descr.t
-                                    and type row=VDescr.Descr.Records.Atom.t)
+                                                               and type row=VDescr.Descr.Records.Atom.t)
            and VDescr : VDescr with type node = Node.t
          end)

--- a/src/lib/sstt/core/sigs.ml
+++ b/src/lib/sstt/core/sigs.ml
@@ -705,7 +705,7 @@ module type Records = sig
   *)
 
   type node
-  
+
   (** @canonical Sstt.Ty.F *)
   module FTy : FTy with type node := node
 
@@ -1225,7 +1225,7 @@ module type Ty = sig
   *)
 
   val all_vars : t -> MixVarSet.t
-  
+
   val all_vars_toplevel : t -> MixVarSet.t
 
   val nodes : t -> t list
@@ -1245,6 +1245,18 @@ module type Ty = sig
   val factorize : t -> t
   (** [factorize t] factorizes equivalent nodes in [t].
       This operation may be expensive since it calls {!equiv} internally.
+  *)
+
+  val with_shared_cache : ('a -> 'b) -> 'a -> 'b
+  (** [with_shared_cache f x] computes [f x]. All call to the subtyping algorithm
+      ([is_empty], [leq], [equiv], [disjoint]) will share the same backtracking
+      cache. Furthermore, given an initial type [t] (existing before the call to
+      [with_shared_cache f x]), the set of types that can be created during the
+      computation by applying (repetitively) projections, union, intersections,
+      and negations to [t] is guaranteed to be finite. In otherwords, within the
+      scope of [with_shared_cache f x], [equal] implies syntactic equality of
+      types. All ressources (memoization and backtracking caches) are freed when
+      [with_shared_cache f x] returns.
   *)
 
 

--- a/src/lib/sstt/core/sigs.ml
+++ b/src/lib/sstt/core/sigs.ml
@@ -1113,7 +1113,7 @@ module type PreNode = sig
   val of_eqs : (Var.t * t) list -> (Var.t * t) list
   val substitute : subst -> t -> t
   val factorize : t -> t
-  val simplify : t -> unit
+  val simplify : t -> t
 
 end
 module type Node = sig

--- a/src/lib/sstt/core/sigs.ml
+++ b/src/lib/sstt/core/sigs.ml
@@ -15,14 +15,6 @@ module type Comparable = sig
   *)
 end
 
-module type Comparable' = sig
-  type t
-  type node
-  val compare' : (node -> node -> int) -> t -> t -> int
-  val equal' : (node -> node -> bool) -> t -> t -> bool
-  val hash' : (node -> int) -> t -> int
-end
-
 module type TyBase = sig
   type t
 
@@ -336,7 +328,6 @@ module type OTy = sig
                                 and type node := node
                                 and type atom := Atom.t
 
-    include Comparable' with type node := node and type t := t (** @inline *)
 
     val get : t -> Atom.t
 
@@ -445,8 +436,6 @@ module type FTy = sig
     and type leaf := OTy.t and type var := RowVar.t
     and module VarSet := RowVarSet
     and module VarMap := RowVarMap
-
-  include Comparable' with type node := node and type t := t (** @inline *)
 
 end
 

--- a/src/lib/sstt/core/sigs.ml
+++ b/src/lib/sstt/core/sigs.ml
@@ -1100,7 +1100,7 @@ module type PreNode = sig
 
   include SetTheoretic with type t := t
   include SetTheoreticOps with type t := t
-  val with_own_cache : ('a -> 'b) -> 'a -> 'b
+  val with_shared_cache : ('a -> 'b) -> 'a -> 'b
 
   val vars : t -> VarSet.t
   val vars_toplevel : t -> VarSet.t

--- a/src/lib/sstt/core/utils/bdd.ml
+++ b/src/lib/sstt/core/utils/bdd.ml
@@ -49,12 +49,6 @@ module Make(N:Atom)(L:Leaf) = struct
   let hnode a p n = Node (a, p, n, 
                           Hash.mix3 (N.hash a) (hash p) (hash n) )
 
-  (* Version less optimized but parametric *)
-  let rec hash' hn hl t =
-    match t with
-    | Leaf (l, _) -> hl l
-    | Node (a, p, n, _)->
-      Hash.mix3 (hn a) (hash' hn hl p) (hash' hn hl n)
 
   let empty = hleaf L.empty
   let any = hleaf L.any
@@ -71,15 +65,6 @@ module Make(N:Atom)(L:Leaf) = struct
       Int.equal h1 h2 &&
       N.equal a1 a2 && equal p1 p2 && equal n1 n2
   
-  (* Version less optimized but parametric *)
-  let rec equal' fn fl t1 t2 =
-    t1 == t2 ||
-    match t1, t2 with
-    | Leaf (l1, _) , Leaf (l2, _) -> fl l1 l2
-    | Node _, Leaf _ | Leaf _, Node _ -> false
-    | Node (a1, p1, n1, _), Node (a2, p2, n2, _) ->
-      fn a1 a2 && equal' fn fl p1 p2 && equal' fn fl n1 n2
-
   let rec compare t1 t2 =
     if t1 == t2 then 0 else
       match t1, t2 with
@@ -92,17 +77,6 @@ module Make(N:Atom)(L:Leaf) = struct
             let c = compare p1 p2 in if c <> 0 then c else
               compare n1 n2
 
-  (* Version less optimized but parametric *)
-  let rec compare' fn fl t1 t2 =
-    if t1 == t2 then 0 else
-      match t1, t2 with
-      | Leaf (l1, _), Leaf (l2, _) -> fl l1 l2
-      | Leaf _, Node _ -> 1
-      | Node _, Leaf _ -> -1
-      | Node (a1, p1, n1, _), Node (a2, p2, n2, _) ->
-        let c = fn a1 a2 in if c <> 0 then c else
-          let c = compare' fn fl p1 p2 in if c <> 0 then c else
-            compare' fn fl n1 n2
 
   (* Smart constructor *)
   let node a p n =

--- a/src/lib/sstt/core/utils/polymorphic.ml
+++ b/src/lib/sstt/core/utils/polymorphic.ml
@@ -13,7 +13,7 @@ module type Leaf = sig
   val map_nodes : (node -> node) -> t -> t
 end
 
-module Make(N:Node)(V:Comparable)(L:Leaf with type node = N.t) = struct
+module Make(V:Comparable)(L:Leaf) = struct
   module A = Atom(V)
   module Bdd = Bdd.Make(A)(L)
   module VarMap = Map.Make(V)
@@ -22,8 +22,7 @@ module Make(N:Node)(V:Comparable)(L:Leaf with type node = N.t) = struct
   type leaf = L.t
   type var = V.t
   type t = Bdd.t
-  type node = N.t
-
+  type node = L.node
   let any = Bdd.any
   let empty = Bdd.empty
 

--- a/src/lib/sstt/core/utils/polymorphic.ml
+++ b/src/lib/sstt/core/utils/polymorphic.ml
@@ -47,7 +47,7 @@ module Make(N:Node)(V:Comparable)(L:Leaf with type node = N.t) = struct
 
   let map f t =
     Bdd.map_leaves f t
-  
+
   let map_nodes f =
     map (L.map_nodes f)
 
@@ -72,7 +72,7 @@ module Make(N:Node)(V:Comparable)(L:Leaf with type node = N.t) = struct
     in
     Bdd.substitute' fp fn t
 
-let weaken s t =
+  let weaken s t =
     let fp v =
       match VarMap.find_opt v s with
       | None -> Bdd.singleton v
@@ -102,8 +102,8 @@ let weaken s t =
     let leq t1 t2 = leq (Bdd.of_dnf t1) (Bdd.of_dnf t2)
   end
   module Dnf = Dnf.Make(Comp)
-  let dnf t = N.with_own_cache (fun t -> Bdd.dnf t |> Dnf.export) t
-  let of_dnf dnf = N.with_own_cache (fun dnf -> Dnf.import dnf |> Bdd.of_dnf) dnf
+  let dnf t = Bdd.dnf t |> Dnf.export
+  let of_dnf dnf = Dnf.import dnf |> Bdd.of_dnf
 
   let simplify t = Bdd.simplify equiv t
 

--- a/src/lib/sstt/core/vdescr.ml
+++ b/src/lib/sstt/core/vdescr.ml
@@ -3,7 +3,7 @@ open Sigs
 
 module Make(N:Node) = struct
   module Descr = Descr.Make(N)
-  include Polymorphic.Make(N)(Var)(Descr)
+  include Polymorphic.Make(Var)(Descr)
 
   let substitute (s:(t,Descr.Records.Atom.t) MixVarMap.t) t =
     t

--- a/src/lib/sstt/types/tallying.ml
+++ b/src/lib/sstt/types/tallying.ml
@@ -393,26 +393,8 @@ module Make(VS:VarSettings) = struct
 
   (* Caching modules *)
 
-  module VDHash = Hashtbl.Make(VDescr)
-  module FDescr = struct
-    (* Intuitively, this module represents a field descriptor in which
-       direct nodes have been inlined. It is used for caching:
-       to ensure termination, caching of field types should be done
-       by comparing the descriptor of the underlying nodes and not only their id. *)
-
-    module TyHash = Hashtbl.Make(Ty)
-    type t = Ty.F.t * VDescr.t TyHash.t
-    let of_field f =
-      let h = TyHash.create 3 in
-      let cache n = TyHash.replace h n (Ty.def n) ; n in
-      Ty.F.map_nodes cache f |> ignore ;
-      f, h
-    let equal (f1,h1) (f2,h2) = Ty.F.equal'
-      (fun n1 n2 -> VDescr.equal (TyHash.find h1 n1) (TyHash.find h2 n2))
-      f1 f2
-    let hash (f,h) = f |> Ty.F.hash' (fun n -> VDescr.hash (TyHash.find h n))
-  end
-  module FDHash = Hashtbl.Make(FDescr)
+  module MemoTy = Hashtbl.Make(Ty)
+  module MemoFTy = Hashtbl.Make(Ty.F)
 
   (* Core tallying algorithm *)
   
@@ -434,19 +416,19 @@ module Make(VS:VarSettings) = struct
     in psi CSS.any ps ns ()
 
   let norm, norm_field =
-    let memo_ty = VDHash.create 17 in
-    let memo_f = FDHash.create 17 in
+    let memo_ty = MemoTy.create 17 in
+    let memo_f = MemoFTy.create 17 in
     let rec norm_ty t =
       if Ty.is_empty t then CSS.any
       else if MixVarSet.subset (Ty.all_vars t) VS.delta then CSS.empty
-      else norm_vdescr (Ty.def t)
-    and norm_vdescr vd =
-      match VDHash.find_opt memo_ty vd with
+      else norm_vdescr t
+    and norm_vdescr t =
+      match MemoTy.find_opt memo_ty t with
       | Some cstr -> cstr
       | None ->
-        VDHash.add memo_ty vd CSS.any;
-        let res = vd |> VDescr.dnf |> CSS.map_conj norm_summand in
-        VDHash.remove memo_ty vd ; res
+        MemoTy.add memo_ty t CSS.any;
+        let res = t |> Ty.def |> VDescr.dnf |> CSS.map_conj norm_summand in
+        MemoTy.remove memo_ty t ; res
     and norm_summand summand =
       match VToplevel.extract_smallest summand with
       | None ->
@@ -539,13 +521,12 @@ module Make(VS:VarSettings) = struct
       in
       norm_tuple_gen ~diff:Ty.F.diff ~disjoint ~norm:norm_field p ns
     and norm_field (f:Ty.F.t) =
-      let fd = FDescr.of_field f in
-      match FDHash.find_opt memo_f fd with
+      match MemoFTy.find_opt memo_f f with
       | Some cstr -> cstr
       | None ->
-        FDHash.add memo_f fd CSS.any;
+        MemoFTy.add memo_f f CSS.any;
         let res = f |> Ty.F.dnf |> CSS.map_conj norm_field_summand in
-        FDHash.remove memo_f fd ; res
+        MemoFTy.remove memo_f f ; res
     and norm_field_summand summand =
       match FToplevel.extract_smallest summand with
       | None ->
@@ -559,8 +540,8 @@ module Make(VS:VarSettings) = struct
     norm_ty, norm_field
 
   let propagate cs =
-    let memo_ty = VDHash.create 17 in
-    let memo_f = FDHash.create 17 in
+    let memo_ty = MemoTy.create 17 in
+    let memo_f = MemoFTy.create 17 in
     let rec aux (prev,prev') ((cs,cs') : CS'.t) =
       let retry_with css =
         let css_prev () = (prev,prev') |> CSS.singleton in
@@ -574,23 +555,21 @@ module Make(VS:VarSettings) = struct
       | Cons (constr, tl), _ ->
         let (t', _, t) = VC.destruct constr in
         let ty = Ty.diff t' t in
-        let def = Ty.def ty in
-        if VDHash.mem memo_ty def then
+        if MemoTy.mem memo_ty t then
           aux (VCS.add constr prev, prev') (tl,cs')
         else
-          let () = VDHash.add memo_ty def () in
+          let () = MemoTy.add memo_ty t () in
           let res = norm ty |> retry_with in
-          VDHash.remove memo_ty def ; res
+          MemoTy.remove memo_ty t ; res
       | Nil, Cons (constr, tl) ->
         let (f', _, f) = FC.destruct constr in
         let f = Ty.F.diff f' f in
-        let def = FDescr.of_field f in
-        if FDHash.mem memo_f def then
+        if MemoFTy.mem memo_f f then
           aux (prev, FCS.add constr prev') (cs,tl)
         else
-          let () = FDHash.add memo_f def () in
+          let () = MemoFTy.add memo_f f () in
           let res = norm_field f |> retry_with in
-          FDHash.remove memo_f def ; res
+          MemoFTy.remove memo_f f ; res
     in
     aux CS'.any cs
 
@@ -636,6 +615,8 @@ module Make(VS:VarSettings) = struct
     let ncss = cs |> CSS.map_conj (fun (s,t) -> norm (Ty.diff s t)) in
     let mcss = ncss |> CSS.to_list |> CSS.map_disj propagate in
     mcss |> CSS.to_list |> List.map solve
+
+  let tally = Ty.with_shared_cache tally
 end
 
 (* =============== Operations on row and field variables =============== *)

--- a/src/lib/sstt/types/transform.ml
+++ b/src/lib/sstt/types/transform.ml
@@ -1,7 +1,7 @@
 open Core
 open Sstt_utils
 
-module VDHash = Hashtbl.Make(VDescr)
+module VDHash = Hashtbl.Make(Ty)
 
 type ctx = {
   cache : Var.t VDHash.t ;
@@ -15,20 +15,22 @@ let transform f t =
   } in
   let rec aux t =
     let vd = Ty.def t in
-    match VDHash.find_opt ctx.cache vd with
+    match VDHash.find_opt ctx.cache t with
     | Some v -> v
     | None ->
       let v = Var.mk "" in
-      VDHash.add ctx.cache vd v ;
+      VDHash.add ctx.cache t v ;
       let vd = f vd |> VDescr.map_nodes aux_ty in
       ctx.eqs <- (v, Ty.of_def vd)::ctx.eqs ;
       v
   and aux_ty t = aux t |> Ty.mk_var in
   let v = aux t in
   let res = Ty.of_eqs ctx.eqs in
-  res 
+  res
   |> List.find_map (fun (v', t) -> if Var.equal v v' then Some t else None)
   |> Option.get
+
+let transform = Ty.with_shared_cache transform
 
 (* Type simplification *)
 
@@ -184,4 +186,5 @@ let simpl_descr ~normalize d =
 
 let simpl_vdescr ~normalize = VDescr.map (simpl_descr ~normalize)
 
-let simplify ?normalize = transform (simpl_vdescr ~normalize)
+let simplify ?normalize =
+  Ty.with_shared_cache (fun t -> transform (simpl_vdescr ~normalize) t)

--- a/src/tests/tests.ml
+++ b/src/tests/tests.ml
@@ -81,7 +81,7 @@ let%expect_test "tests" =
     var3: empty
     var4: any
     var5: 'x
-    print1: (any -> any) | (int -> bool -> true)
+    print1: (int -> bool -> true) | (any -> any)
     print2: (true, true) | (false, false)
     print3: { l1 : false ; l2 : true } | { l1 : true ; l2 : true ..}
     print4: nil | int | (any, x1) where x1 = nil | (any, x1)
@@ -89,7 +89,7 @@ let%expect_test "tests" =
     print6: 'b & ('a, 'b) | 'a
     print7: ~true
     print8: ~(any -> bool)
-    print9: ~((any -> bool) & (true -> false))
+    print9: ~((true -> false) & (any -> bool))
     print10: ~((true, false) | (false, true))
     print11: bool
     print13: 'y

--- a/src/tests/tests.ml
+++ b/src/tests/tests.ml
@@ -83,7 +83,7 @@ let%expect_test "tests" =
     var5: 'x
     print1: (int -> bool -> true) | (any -> any)
     print2: (true, true) | (false, false)
-    print3: { l1 : false ; l2 : true } | { l1 : true ; l2 : true ..}
+    print3: { l1 : true ; l2 : true ..} | { l1 : false ; l2 : true }
     print4: nil | int | (any, x1) where x1 = nil | (any, x1)
     print5: (int -> int) -> bool -> bool
     print6: 'b & ('a, 'b) | 'a
@@ -115,11 +115,11 @@ let%expect_test "tests" =
               'Y: 'Y & 'y
             ]
     tally6: [
-              'Z: empty
-            ]
-            [
               'X: 'Z | 'X ;
               'Y: 'Y & bool
+            ]
+            [
+              'Z: empty
             ]
     tally7: [
               'X: empty
@@ -181,11 +181,11 @@ let%expect_test "tests" =
                'Y: bool
              ]
     tally16: [
-               'A: empty
-             ]
-             [
                'X: 'A | 'X ;
                'Y: 'B & 'Y
+             ]
+             [
+               'A: empty
              ]
     tally17: [
                'X: int | 'X ;

--- a/src/tests/tests.ml
+++ b/src/tests/tests.ml
@@ -21,7 +21,7 @@ let%expect_test "tests" =
     empty2: true
     atom1: false
     atom2: true
-    tags1: tag((true, false) | (false, true))
+    tags1: tag((false, true) | (true, false))
     tags2: tag1(true, false) | tag2(false, true)
     tags3: true
     tags4: 42
@@ -82,7 +82,7 @@ let%expect_test "tests" =
     var4: any
     var5: 'x
     print1: (int -> bool -> true) | (any -> any)
-    print2: (true, true) | (false, false)
+    print2: (false, false) | (true, true)
     print3: { l1 : true ; l2 : true ..} | { l1 : false ; l2 : true }
     print4: nil | int | (any, x1) where x1 = nil | (any, x1)
     print5: (int -> int) -> bool -> bool
@@ -90,7 +90,7 @@ let%expect_test "tests" =
     print7: ~true
     print8: ~(any -> bool)
     print9: ~((true -> false) & (any -> bool))
-    print10: ~((true, false) | (false, true))
+    print10: ~((false, true) | (true, false))
     print11: bool
     print13: 'y
     print14: nil, (bool, x1) where x1 = nil | (bool, x1)
@@ -295,7 +295,7 @@ let%expect_test "tests_ext" =
       list_42_43: [ 42 43 any* ]
       int_list: [ int* ]
       list_not_only_a: [ any any* (~'a) any* | (~'a) any* ]
-      list_union: [ 43 42 any* | 42 any* ]
+      list_union: [ 42 any* | 43 42 any* ]
       list_regexp: [ ('b | 'a)* ]
       list_with_vars: 42::('a & [ int* ])
       char_any: char

--- a/sstt-bin.opam
+++ b/sstt-bin.opam
@@ -12,6 +12,7 @@ depends: [
   "sstt-repl"
   "yojson"
   "odoc" {with-doc}
+  "menhir" {>= "20180523"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/sstt-web.opam
+++ b/sstt-web.opam
@@ -15,6 +15,7 @@ depends: [
   "js_of_ocaml-compiler"
   "wasm_of_ocaml-compiler"
   "odoc" {with-doc}
+  "menhir" {>= "20180523"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/sstt.opam
+++ b/sstt.opam
@@ -13,6 +13,7 @@ depends: [
   "dune" {>= "3.17"}
   "zarith"
   "odoc" {with-doc}
+  "menhir" {>= "20180523"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
This PR implements shallow memoization of nodes using the effect system. It's better reviewed commit by commit as it adds features incrementally.

## Highlights

- the cache data structure is now a record containing fields holding tables for all cached operations
- `with_own_cache` is renamed `with_shared_cache` and exposed in `Ty`
- operations `cons`, `cap`, `cup` and `diff` now try to obtain a cache by performing the `GetCache` effect. If this fails (exception `Unhandled GetCache`) then the just perform as usual, creating a fresh Node.t to store their result. If this succeeds, the cache is queried first to see if a result Node already exists (otherwise the entry is created)
- `with_shared_cache` is made re-entrant. The first time the handler catches the `GetCache` effects, the effect is propagated upward to reach the highest `with_shared_cache` handler on the call stack. Once it's found, it's cache is propagated downward.
- the calls to `is_empty` is now protected inside `Node` by `with_shared_cache` (`equiv`, `simplify` and `factorize` are also protected, but for performances reasons, so that all the subtyping operations they perform share the same cache, see commit bbdff734c433366a3465d023d6d1d86e420c4c10)
- with that, all occurrences of `N.with_own_cache` can be removed from `Core`. This also simplifies the `Polymorphic` functor (the `N` parameter is not needed anymore)
- lastly, tallying is made to use types instead of descr, and the machinery for field types is removed

## Performance impact
On the `main` branch of `MLSem` running `./bench.sh time` on my test machine yields:
```
Run 1 ... 4.30
Run 2 ... 4.26
Run 3 ... 4.26
Run 4 ... 4.25
Total of 4 runs: 4.26
```
while running the large "recursive object" tests yields
```
===== Processing test_objects.ml =====
diverge: any -> empty (checked in 1ms)
magic: empty (checked in 0ms)
an_integer: ∀'a,'b,'c. x2 where x1 = (x2 -> (x2, x2)) & (~{ _name : (~(Numeric_ |
Integer_))? ; plus : (x2 -> x2) & ({ _name : (~enum)? ; coerce : x2 -> ('b &
_add_('c, 'a), 'c) ..} -> 'a) ; coerce : x1 } -> (float, float)) and x2 = {
_name : (~(Numeric_ | Integer_))? ; plus : (x2 -> x2) & ({ _name : (~enum)? ;
coerce : x2 -> ('b & _add_('c, 'a), 'c) ..} -> 'a) ; coerce : x1 } (checked in 11ms)
test0: ∀'a,'b,'c. x2 where x1 = (x2 -> (x2, x2)) & (~{ _name : (~(Numeric_ |
Integer_))? ; plus : (x2 -> x2) & ({ _name : (~enum)? ; coerce : x2 -> ('b &
{ plus : 'c -> 'a ..}, 'c) ..} -> 'a) ; coerce : x1 } -> (float, float)) and
x2 = { _name : (~(Numeric_ | Integer_))? ; plus : (x2 -> x2) & ({ _name :
(~enum)? ; coerce : x2 -> ('b & { plus : 'c -> 'a ..}, 'c) ..} -> 'a) ;
coerce : x1 } (checked in 61694ms)
Total time: 61.71s
```

with this PR we have
```
Run 1 ... 4.43
Run 2 ... 4.42
Run 3 ... 4.43
Run 4 ... 4.45
Total of 4 runs: 4.43
```
and
```
===== Processing test_objects.ml =====
diverge: any -> empty (checked in 1ms)
magic: empty (checked in 0ms)
an_integer: ∀'a,'b,'c. x2 where x1 = (x2 -> (x2, x2)) & (~{ _name : (~(Numeric_ |
Integer_))? ; plus : (x2 -> x2) & ({ _name : (~enum)? ; coerce : x2 -> ('b &
_add_('c, 'a), 'c) ..} -> 'a) ; coerce : x1 } -> (float, float)) and x2 = {
_name : (~(Numeric_ | Integer_))? ; plus : (x2 -> x2) & ({ _name : (~enum)? ;
coerce : x2 -> ('b & _add_('c, 'a), 'c) ..} -> 'a) ; coerce : x1 } (checked in 15ms)
test0: ∀'a,'b,'c. x2 where x1 = (x2 -> (x2, x2)) & (~{ _name : (~(Numeric_ |
Integer_))? ; plus : (x2 -> x2) & ({ _name : (~enum)? ; coerce : x2 -> ('b &
{ plus : 'c -> 'a ..}, 'c) ..} -> 'a) ; coerce : x1 } -> (float, float)) and
x2 = { _name : (~(Numeric_ | Integer_))? ; plus : (x2 -> x2) & ({ _name :
(~enum)? ; coerce : x2 -> ('b & { plus : 'c -> 'a ..}, 'c) ..} -> 'a) ;
coerce : x1 } (checked in 3920ms)
Total time: 3.94s
```
so the average case is just slightly slower by about 4% (on normal "small" types the effect machinery compensate the caching). But on large the large example of recursive types, the speed up is excellent (61s down to less than 4s). 