### PR TITLE
Represent Ty.O using a BDD

### DIFF
--- a/src/lib/repl/parsing/ast.ml
+++ b/src/lib/repl/parsing/ast.ml
@@ -263,10 +263,10 @@ and build_field env t =
     Ty.F.neg f, env
   | TUnop (TOption, t) ->
     let f, env = build_field env t in
-    Ty.F.cup f (Ty.F.mk_descr Ty.O.absent), env
+    Ty.F.cup f (Ty.O.Atom.absent |> Ty.O.mk |> Ty.F.mk_descr), env
   | _ ->
     let ty, env = build_ty env t in
-    Ty.F.mk_descr (Ty.O.required ty), env
+    Ty.F.mk_descr (Ty.O.Atom.required ty |> Ty.O.mk), env
 
 let build_row env t : Row.t * env =
   match t with

--- a/src/lib/sstt/core/components/fields.ml
+++ b/src/lib/sstt/core/components/fields.ml
@@ -2,17 +2,35 @@ open Base
 open Sigs
 open Sstt_utils
 
-module OTy(N:Node) = struct
+module OAtom(N:Node) = struct
   type node = N.t
   type t = node * bool
 
+  let map_nodes f (n,b) = (f n, b)
+  let direct_nodes (n,_) = [n]
+  let simplify t = t
+  let equal (n1,b1) (n2,b2) =
+    Bool.equal b1 b2 && N.equal n1 n2
+  let compare (n1,b1) (n2,b2) =
+    Bool.compare b1 b2 |> ccmp
+      N.compare n1 n2
+  let equal' f (n1,b1) (n2,b2) = Bool.equal b1 b2 && f n1 n2
+  let compare' f (n1,b1) (n2,b2) = Bool.compare b1 b2 |> ccmp f n1 n2
+  let hash (n, b) = Hash.(mix (bool b) (N.hash n))
+  let hash' f (n, b) = Hash.(mix (bool b) (f n))
+
+  let is_optional (_,b) = b
+  let is_required (_,b) = not b
+
   let any = (N.any, true)
   let empty = (N.empty, false)
+  let present = (N.any, false)
   let absent = (N.empty, true)
   let required t = (t, false)
   let optional t = (t, true)
   let get (t,_) = t
 
+  (* Set-theoretic operations *)
   let cap (n1, b1) (n2, b2) = (N.cap n1 n2, b1 && b2)
   let cap = fcap ~empty ~any ~cap
   let cup (n1, b1) (n2, b2) = (N.cup n1 n2, b1 || b2)
@@ -27,27 +45,56 @@ module OTy(N:Node) = struct
   let disj lst =
     let ns, bs = List.split lst in
     (N.disj ns, List.fold_left (||) false bs)
-
   let is_empty (n,b) = not b && N.is_empty n
-  let is_any (n,b) = b && N.is_any n
-  let is_absent (n,b) = b && N.is_empty n
-  let is_optional (_,b) = b
-  let is_required (_,b) = not b
-  let leq (n1,b1) (n2,b2) = (not b1 || b2) && N.leq n1 n2
-  let equiv (n1,b1) (n2,b2) = b1 = b2 && N.equiv n1 n2
-  let disjoint (n1,b1) (n2,b2) = not (b1 && b2) && N.disjoint n1 n2
+end
 
-  let equal (n1,b1) (n2,b2) = b1 = b2 && N.equal n1 n2
-  let equal' f (n1,b1) (n2,b2) = b1 = b2 && f n1 n2
-  let compare (n1,b1) (n2,b2) = Bool.compare b1 b2 |> ccmp N.compare n1 n2
-  let compare' f (n1,b1) (n2,b2) = Bool.compare b1 b2 |> ccmp f n1 n2
+module OTy(N:Node) = struct
+  module Atom = OAtom(N)
+  module BoolLeaf = Bdd.BoolLeaf
+  module Bdd = Bdd.Make(Atom)(BoolLeaf)
 
-  let map_nodes f (n,b) = (f n, b)
-  let direct_nodes (n,_) = [n]
-  let simplify t = t
+  type t = Bdd.t
+  type node = N.t
 
-  let hash (n, b) = Hash.(mix (bool b) (N.hash n))
-  let hash' f (n, b) = Hash.(mix (bool b) (f n))
+  let any = Bdd.any
+  let empty = Bdd.empty
+  let mk a = Bdd.singleton a
+
+  let cap = Bdd.cap
+  let cup = Bdd.cup
+  let neg = Bdd.neg
+  let diff = Bdd.diff
+
+  let get (ps,ns) =
+    Atom.diff (Atom.conj ps) (Atom.disj ns)
+  let is_clause_empty (ps,ns,b) =
+    not b || Atom.is_empty (get (ps,ns))
+  let is_empty t = Bdd.for_all_lines is_clause_empty t
+  let get = Bdd.fold_lines (fun acc (ps,ns,b) ->
+    if b then Atom.cup acc (get (ps,ns)) else acc) Atom.empty
+
+  let equal = Bdd.equal
+  let compare = Bdd.compare
+  let hash = Bdd.hash
+  let equal' f = Bdd.equal' (Atom.equal' f) (BoolLeaf.equal)
+  let compare' f = Bdd.compare' (Atom.compare' f) (BoolLeaf.compare)
+  let hash' f = Bdd.hash' (Atom.hash' f) (BoolLeaf.hash)
+
+  let leq t1 t2 = diff t1 t2 |> is_empty
+  let equiv t1 t2 = leq t1 t2 && leq t2 t1
+  module Comp = struct
+    type atom = Atom.t
+    let atom_is_valid _ = true
+    let leq t1 t2 = leq (Bdd.of_dnf t1) (Bdd.of_dnf t2)
+  end
+  module Dnf = Dnf.LMake(Comp)
+  let dnf t = N.with_own_cache (fun t -> Bdd.dnf t |> Dnf.export) t
+  let of_dnf dnf = N.with_own_cache (fun dnf -> Dnf.import dnf |> Bdd.of_dnf) dnf
+
+  let direct_nodes t = Bdd.atoms t |> List.concat_map Atom.direct_nodes
+  let map_nodes f t = Bdd.map_nodes (Atom.map_nodes f) t
+  let map f t = Bdd.map_nodes f t
+  let simplify t = Bdd.simplify equiv t
 end
 
 module Make(N:Node) = struct

--- a/src/lib/sstt/core/components/records.ml
+++ b/src/lib/sstt/core/components/records.ml
@@ -16,9 +16,10 @@ module Atom
 
   let hash t =
     Hash.(mix (FTy.hash t.tail) (LabelMap.hash t.bindings))
-  let map_nodes f t =
-    { bindings = LabelMap.map (FTy.map_nodes f) t.bindings ;
-      tail = FTy.map_nodes f t.tail }
+  let map f t =
+    { bindings = LabelMap.map f t.bindings ;
+      tail = f t.tail }
+  let map_nodes f t = map (FTy.map_nodes f) t
   let direct_nodes t =
     let nb = t.bindings |> LabelMap.values |> List.concat_map FTy.direct_nodes in
     let nt = FTy.direct_nodes t.tail in

--- a/src/lib/sstt/core/sigs.ml
+++ b/src/lib/sstt/core/sigs.ml
@@ -280,48 +280,65 @@ end
 
 (* OTy *)
 
+module type OAtom = sig
+  type node
+
+  type t = node * bool
+  (** Whenever the boolean component is [true], it means that the type contains the
+    undefined element {m \bot}. Otherwise, when the boolean component is [false],
+    the type is equivalent to a plain {!Ty.t} type. *)
+
+  include Comparable with type t := t
+  val map_nodes : (node -> node) -> t -> t
+
+  val is_required : t -> bool
+  (** Tests whether {m \bot \not\in t}. *)
+
+  val is_optional : t -> bool
+  (** Tests whether {m \bot \in t}*)
+
+  val any : t
+  val empty : t
+
+  val present : t
+  (** [present] is the singleton type containing all values but the undefined value, {m \bot}. *)
+
+  val absent : t
+  (** [absent] is the singleton type containing the undefined value, {m \bot}. *)
+
+  val required : node -> t
+  (** [required t] returns the type [t, false]. *)
+
+  val optional : node -> t
+  (** [optional t] returns [t, true] which represents the type {m t\cup \bot}. *)
+
+  val get : t -> node
+  (** Returns [get (t, b)] returns [t]. *)
+end
+
 module type OTy = sig
     (** Optional types are subsets of {%html: <span style='font-size:large'>𝟙</span>%}{m \cup\bot}. They are used for the type of
         record fields, to denote the fact that a field may be absent.
     *)
+    
+    type t
+    (** The type of types optional types. *)
 
     type node
-    (** An alias for the type {!Ty.t}. *)
 
-    type t = node * bool
-    (** The type of optional types. Whenever
-        the boolean component is [true], it means that the type contains the
-        undefined element {m \bot}. Otherwise, when the boolean component is [false],
-        the type is equivalent to a plain {!Ty.t} type. *)
+    (**@inline*)
+    include ComponentBase with type t := t
+                          and type node := node
+                          and module type Atom := (OAtom with type node := node)
 
-
-    include TyBase with type node := node and type t := t (** @inline *)
+    (**@inline*)
+    include ConstrComponentOps with type t := t
+                                and type node := node
+                                and type atom := Atom.t
 
     include Comparable' with type node := node and type t := t (** @inline *)
 
-    val absent : t
-    (** [absent] is the singleton type containing the undefined value, {m \bot}. *)
-
-    val required : node -> t
-    (** [required t] returns the type [t, false]. *)
-
-    val optional : node -> t
-    (** [optional t] returns [t, true] which represents the type {m t\cup \bot}. *)
-
-    (** @inline *)
-    include SetTheoretic with type t := t
-
-    val is_absent : t -> bool
-    (** Tests whether {m \bot \equiv t}. *)
-
-    val is_required : t -> bool
-    (** Tests whether {m \bot \not\in t}. *)
-
-    val is_optional : t -> bool
-    (** Tests whether {m \bot \in t}*)
-
-    val get : t -> node
-    (** Returns [get (t, b)] returns [t]. *)
+    val get : t -> Atom.t
   end
 
 (* Polymorphic layers *)

--- a/src/lib/sstt/core/sigs.ml
+++ b/src/lib/sstt/core/sigs.ml
@@ -641,7 +641,10 @@ module type RecordAtom = sig
 
   include Comparable with type t := t
   val map_nodes : (node -> node) -> t -> t
-  (** [map_nodes f r] applies [f] to all nodes in [r.bindings]. *)
+  (** [map_nodes f r] applies [f] to all nodes in [r]. *)
+
+  val map : (field -> field) -> t -> t
+  (** [map f r] applies [f] to all fields in [r]. *)
 
   val substitute : t RowVarMap.t -> t -> t
   (** [substitute s r] applies the substitution [s] to [r]. *)

--- a/src/lib/sstt/types/extensions/abstracts.ml
+++ b/src/lib/sstt/types/extensions/abstracts.ml
@@ -49,17 +49,17 @@ let encode_params encoding ps =
     match encoding with
     | ECov vs ->
       List.combine vs ps |> List.mapi (fun i (v,p) ->
-        let pos = label_of_position false i, Ty.O.optional p in
-        let neg = label_of_position true i, Ty.O.optional (Ty.neg p) in
+        let pos = label_of_position false i, Ty.O.Atom.optional p |> Ty.O.mk in
+        let neg = label_of_position true i, Ty.O.Atom.optional (Ty.neg p) |> Ty.O.mk in
         match v with
         | Cov -> [pos] | Cav -> [neg] | Inv -> [pos;neg]
       ) |> List.concat |> Atom.LabelMap.of_list
     | EInv _ ->
       ps |> List.mapi (fun i p ->
-        label_of_position false i, Ty.O.optional p
+        label_of_position false i, Ty.O.Atom.optional p |> Ty.O.mk
       ) |> Atom.LabelMap.of_list
   in
-  { Atom.bindings ; Atom.tail=Ty.O.absent }
+  { Atom.bindings ; Atom.tail=Ty.O.mk Ty.O.Atom.absent }
   |> of_atom |> Descr.mk_records |> Ty.mk_descr
 
 let mk tag ps =
@@ -77,8 +77,8 @@ let extract_dnf tag dnf =
   let vs = parameters tag in
   let extract_param record i v =
     match v with
-    | Inv | Cov -> find (label_of_position false i) record |> Ty.O.get
-    | Cav -> find (label_of_position true i) record |> Ty.O.get |> Ty.neg
+    | Inv | Cov -> find (label_of_position false i) record |> Ty.O.get |> Ty.O.Atom.get
+    | Cav -> find (label_of_position true i) record |> Ty.O.get |> Ty.O.Atom.get |> Ty.neg
   in
   let extract_params record =
     vs |> List.mapi (extract_param record)

--- a/src/lib/sstt/types/op.ml
+++ b/src/lib/sstt/types/op.ml
@@ -118,8 +118,8 @@ module Records' = struct
   let merge a1 a2 =
     let open Atom in
     let dom = LabelSet.union (Atom.dom a1) (Atom.dom a2) in
-    let is_opt f = Ty.F.get_descr f |> Ty.O.is_optional in
-    let present = Ty.F.mk_descr (Ty.O.required Ty.any) in
+    let is_opt f = Ty.F.get_descr f |> Ty.O.get |> Ty.O.Atom.is_optional in
+    let present = Ty.F.mk_descr (Ty.O.mk Ty.O.Atom.present) in
     let bindings = dom |> LabelSet.to_list |> List.map (fun lbl ->
         let oty1, oty2 = Atom.find lbl a1, Atom.find lbl a2 in
         let oty = if is_opt oty2 then
@@ -134,7 +134,8 @@ module Records' = struct
 
   let remove a lbl =
     let open Atom in
-    let bindings = a.Atom.bindings |> LabelMap.add lbl (Ty.O.absent |> Ty.F.mk_descr) in
+    let bindings = a.Atom.bindings |>
+      LabelMap.add lbl (Ty.O.Atom.absent |> Ty.O.mk |> Ty.F.mk_descr) in
     { bindings ; tail=a.tail } |> of_atom
 
 end

--- a/src/lib/sstt/types/printer/printer.ml
+++ b/src/lib/sstt/types/printer/printer.ml
@@ -201,7 +201,7 @@ let tuple lst =
 let rec ty_of_fop fop =
   match fop with
   | FRowVar v -> Ty.F.mk_var v
-  | FTy (d,b) -> Ty.F.mk_descr (d.ty,b)
+  | FTy (d,b) -> Ty.O.mk (d.ty,b) |> Ty.F.mk_descr
   | FUnop (FNeg, fop) -> Ty.F.neg (ty_of_fop fop)
   | FBinop (FDiff, fop1, fop2) -> Ty.F.diff (ty_of_fop fop1) (ty_of_fop fop2)
   | FVarop (FCup, fops) -> Ty.F.disj (List.map ty_of_fop fops)
@@ -309,7 +309,8 @@ let resolve_tuples ctx a =
 
 let resolve_field nf f =
   let aux_oty oty =
-    FTy (nf (Ty.O.get oty), Ty.O.is_optional oty)
+    let ty, b = Ty.O.get oty in
+    FTy (nf ty, b)
   in
   let aux_var v = FRowVar v in
   let aux_ps ps = ps |> List.map aux_var in

--- a/src/lib/sstt/types/tallying.ml
+++ b/src/lib/sstt/types/tallying.ml
@@ -533,9 +533,9 @@ module Make(VS:VarSettings) = struct
             (fun () -> norm_record_tests (tl,p) (bs'::ns) ns')
         )
     and norm_record_bindings p ns =
-      let disjoint s1 s2 =
-        let o = Ty.F.cap s1 s2 |> Ty.F.get_descr in
-        Ty.O.is_required o && Ty.O.get o |> Ty.is_empty
+      let disjoint s1 s2 = (* TODO: should be exported... *)
+        let ty, b = Ty.F.cap s1 s2 |> Ty.F.get_descr |> Ty.O.get in
+        not b && Ty.is_empty ty
       in
       norm_tuple_gen ~diff:Ty.F.diff ~disjoint ~norm:norm_field p ns
     and norm_field (f:Ty.F.t) =
@@ -552,7 +552,8 @@ module Make(VS:VarSettings) = struct
         let (_,_,oty) = summand in
         norm_oty oty
       | Some cs -> CSS.single' (FC.mk cs)
-    and norm_oty (n,o) =
+    and norm_oty oty =
+      let n, o = Ty.O.get oty in
       if o then CSS.empty else norm_ty n
     in
     norm_ty, norm_field

--- a/src/lib/sstt/types/transform.ml
+++ b/src/lib/sstt/types/transform.ml
@@ -110,6 +110,11 @@ let regroup_tuples n (ps,ns) =
   let p = regroup_pos_line ~any:Ty.any ~conj:Ty.conj n ps in
   regroup_neg_line ~diff:Ty.diff ~leq:Ty.leq p ns
 
+let simpl_oty a = Ty.O.mk (Ty.O.get a)
+let simpl_fty a = Ty.F.map simpl_oty a
+let simpl_record_atom a = Records.Atom.map simpl_fty a
+let simpl_record_clause (ps,ns) =
+  List.map simpl_record_atom ps, List.map simpl_record_atom ns
 let regroup_records (ps,ns) =
   let open Records.Atom in
   let tail, labels = ref Ty.F.any, ref LabelSet.empty in
@@ -117,9 +122,9 @@ let regroup_records (ps,ns) =
     labels := LabelSet.union !labels (dom r) ; tail := Ty.F.cap !tail r.tail) ;
   ns |> List.iter (fun r -> labels := LabelSet.union !labels (dom r)) ;
   let labels, tail = !labels, !tail in
-  let is_empty s =
-    let o = Ty.F.get_descr s in
-    Ty.O.is_required o && Ty.O.get o |> Ty.is_empty
+  let is_empty s = (* TODO: should be exported... *)
+    let (ty,b) = Ty.F.get_descr s |> Ty.O.get in
+    not b && Ty.is_empty ty
   in
   let leq s1 s2 = is_empty (Ty.F.diff s1 s2) in
   let ns1, ns2 = List.partition (fun r -> leq tail r.tail) ns in
@@ -138,7 +143,8 @@ let simpl_arrows ~normalize a =
   Arrows.dnf a |> List.map regroup_arrows |> filter_dnf ~normalize to_ty |> Arrows.of_dnf
 let simpl_records ~normalize r =
   let to_ty a = Descr.mk_record a |> Ty.mk_descr in
-  Records.dnf r |> List.map regroup_records |> filter_dnf ~normalize to_ty |> Records.of_dnf
+  Records.dnf r |> List.map regroup_records |> List.map simpl_record_clause
+  |> filter_dnf ~normalize to_ty |> Records.of_dnf
 let simpl_tuples ~normalize p =
   let n = TupleComp.len p in
   let to_ty a = Descr.mk_tuple a |> Ty.mk_descr in


### PR DESCRIPTION
Fixes an issue when building a type, where an intersection of two Ty.O was creating a new (uninitialized) node on-the-fly.

@Tchou I think we should export `is_empty` (and related operations) in Ty.F and Ty.O, but currently it is complex to do so because of the necessity to call `with_own_cache` for each exported function. However I think it will not be a problem anymore after #27 is merged.