### PR TITLE
Small simplifications around record types

### DIFF
--- a/src/lib/sstt/core/components/fields.ml
+++ b/src/lib/sstt/core/components/fields.ml
@@ -52,10 +52,8 @@ module OTy(N:Node) = struct
   module Atom = OAtom(N)
   module BoolLeaf = Bdd.BoolLeaf
   module Bdd = Bdd.Make(Atom)(BoolLeaf)
-
+  module Node = N
   type t = Bdd.t
-  type node = N.t
-
   let any = Bdd.any
   let empty = Bdd.empty
   let mk a = Bdd.singleton a
@@ -99,7 +97,7 @@ end
 
 module Make(N:Node) = struct
   module OTy = OTy(N)
-  include Polymorphic.Make(N)(RowVar)(OTy)
+  include Polymorphic.Make(RowVar)(OTy)
 
   let equal' f = Bdd.equal' RowVar.equal (OTy.equal' f)
   let compare' f = Bdd.compare' RowVar.compare (OTy.compare' f)

--- a/src/lib/sstt/core/components/records.ml
+++ b/src/lib/sstt/core/components/records.ml
@@ -2,15 +2,11 @@ open Base
 open Sigs
 open Sstt_utils
 
-module MakeLabelMap
-  (FTy:Polymorphic' with type var = RowVar.t and module VarMap = RowVarMap and module VarSet = RowVarSet)
-  (N:Node) = Hash.MapList(Label)(FTy)
-
 module Atom
   (FTy:Polymorphic' with type var = RowVar.t and module VarMap = RowVarMap and module VarSet = RowVarSet)
   (N:Node) = struct
 
-  module LabelMap = MakeLabelMap(FTy)(N)
+  module LabelMap = Hash.MapList(Label)(FTy)
   type node = N.t
   type t = { bindings : LabelMap.t ; tail : FTy.t }
 
@@ -70,7 +66,7 @@ module Atom'
   (FTy:Polymorphic' with type var = RowVar.t and module VarMap = RowVarMap and module VarSet = RowVarSet)
   (N:Node) = struct
 
-  module LabelMap = MakeLabelMap(FTy)(N)
+  module LabelMap = Hash.MapList(Label)(FTy)
   module LabelSet = LabelMap.Set
   type node = N.t
   type t = { bindings : LabelMap.t ; tail : FTy.t ;

--- a/src/lib/sstt/core/descr.ml
+++ b/src/lib/sstt/core/descr.ml
@@ -8,6 +8,7 @@ module Make(N:Node) = struct
   module Records = Records.Make(N)
   module Tuples = Tuples.Make(N)
   module Tags = Tags.Make(N)
+  module Node = N
 
   type component =
     | Intervals of Intervals.t
@@ -26,8 +27,6 @@ module Make(N:Node) = struct
     tags : Tags.t ;
     others : bool
   }
-  type node = N.t
-
   let any = {
     enums = Enums.any ;
     tags = Tags.any  ;

--- a/src/lib/sstt/core/utils/polymorphic.ml
+++ b/src/lib/sstt/core/utils/polymorphic.ml
@@ -7,13 +7,13 @@ end
 
 module type Leaf = sig
   include Bdd.Leaf
-  type node
+  module Node : Node
   val is_empty : t -> bool
-  val direct_nodes : t -> node list
-  val map_nodes : (node -> node) -> t -> t
+  val direct_nodes : t -> Node.t list
+  val map_nodes : (Node.t -> Node.t) -> t -> t
 end
 
-module Make(N:Node)(V:Comparable)(L:Leaf with type node = N.t) = struct
+module Make(V:Comparable)(L:Leaf) = struct
   module A = Atom(V)
   module Bdd = Bdd.Make(A)(L)
   module VarMap = Map.Make(V)
@@ -22,7 +22,7 @@ module Make(N:Node)(V:Comparable)(L:Leaf with type node = N.t) = struct
   type leaf = L.t
   type var = V.t
   type t = Bdd.t
-  type node = N.t
+  type node = L.Node.t
 
   let any = Bdd.any
   let empty = Bdd.empty
@@ -102,8 +102,8 @@ let weaken s t =
     let leq t1 t2 = leq (Bdd.of_dnf t1) (Bdd.of_dnf t2)
   end
   module Dnf = Dnf.Make(Comp)
-  let dnf t = N.with_own_cache (fun t -> Bdd.dnf t |> Dnf.export) t
-  let of_dnf dnf = N.with_own_cache (fun dnf -> Dnf.import dnf |> Bdd.of_dnf) dnf
+  let dnf t = L.Node.with_own_cache (fun t -> Bdd.dnf t |> Dnf.export) t
+  let of_dnf dnf = L.Node.with_own_cache (fun dnf -> Dnf.import dnf |> Bdd.of_dnf) dnf
 
   let simplify t = Bdd.simplify equiv t
 

--- a/src/lib/sstt/core/vdescr.ml
+++ b/src/lib/sstt/core/vdescr.ml
@@ -3,7 +3,7 @@ open Sigs
 
 module Make(N:Node) = struct
   module Descr = Descr.Make(N)
-  include Polymorphic.Make(N)(Var)(Descr)
+  include Polymorphic.Make(Var)(Descr)
 
   let substitute (s:(t,Descr.Records.Atom.t) MixVarMap.t) t =
     t

--- a/src/lib/sstt/types/tallying.ml
+++ b/src/lib/sstt/types/tallying.ml
@@ -12,8 +12,8 @@ let solve_recfield v f =
     )
   in
   let eqs = VHT.to_seq nodes |> List.of_seq |> List.map (fun (v',ty') ->
-    v', Subst.apply (Subst.singleton2 v (Row.all_fields f)) ty'
-  ) in
+      v', Subst.apply (Subst.singleton2 v (Row.all_fields f)) ty'
+    ) in
   let s = Ty.of_eqs eqs |> Subst.of_list1 in
   f |> Ty.F.map_nodes (fun n -> Subst.apply s n)
 
@@ -394,28 +394,17 @@ module Make(VS:VarSettings) = struct
   (* Caching modules *)
 
   module VDHash = Hashtbl.Make(VDescr)
-  module FDescr = struct
-    (* Intuitively, this module represents a field descriptor in which
-       direct nodes have been inlined. It is used for caching:
-       to ensure termination, caching of field types should be done
-       by comparing the descriptor of the underlying nodes and not only their id. *)
-
-    module TyHash = Hashtbl.Make(Ty)
-    type t = Ty.F.t * VDescr.t TyHash.t
-    let of_field f =
-      let h = TyHash.create 3 in
-      let cache n = TyHash.replace h n (Ty.def n) ; n in
-      Ty.F.map_nodes cache f |> ignore ;
-      f, h
-    let equal (f1,h1) (f2,h2) = Ty.F.equal'
-      (fun n1 n2 -> VDescr.equal (TyHash.find h1 n1) (TyHash.find h2 n2))
-      f1 f2
-    let hash (f,h) = f |> Ty.F.hash' (fun n -> VDescr.hash (TyHash.find h n))
-  end
-  module FDHash = Hashtbl.Make(FDescr)
+  module FDHash = Hashtbl.Make(struct
+      type t = Ty.F.t
+      (* Bypass the first layer of Node reference and compare
+         using one level of VDescr.
+      *)
+      let equal = Ty.(F.equal' (fun n1 n2 -> VDescr.equal (def n1) (def n2)))
+      let hash = Ty.(F.hash' (fun n -> VDescr.hash (def n)))
+    end)
 
   (* Core tallying algorithm *)
-  
+
   let norm_tuple_gen ~diff ~disjoint ~norm ps ns =
     (* Same algorithm as for subtyping tuples.
        We define it outside norm below so that its type can be
@@ -529,9 +518,9 @@ module Make(VS:VarSettings) = struct
       | [] -> norm_record_bindings p ns
       | (tl',bs')::ns' ->
         CSS.cup_lazy (norm_record_tests (tl,p) ns ns') (fun () ->
-          CSS.cap_lazy (Ty.F.cap tl (Ty.F.neg tl') |> norm_field)
-            (fun () -> norm_record_tests (tl,p) (bs'::ns) ns')
-        )
+            CSS.cap_lazy (Ty.F.cap tl (Ty.F.neg tl') |> norm_field)
+              (fun () -> norm_record_tests (tl,p) (bs'::ns) ns')
+          )
     and norm_record_bindings p ns =
       let disjoint s1 s2 = (* TODO: should be exported... *)
         let ty, b = Ty.F.cap s1 s2 |> Ty.F.get_descr |> Ty.O.get in
@@ -539,13 +528,12 @@ module Make(VS:VarSettings) = struct
       in
       norm_tuple_gen ~diff:Ty.F.diff ~disjoint ~norm:norm_field p ns
     and norm_field (f:Ty.F.t) =
-      let fd = FDescr.of_field f in
-      match FDHash.find_opt memo_f fd with
+      match FDHash.find_opt memo_f f with
       | Some cstr -> cstr
       | None ->
-        FDHash.add memo_f fd CSS.any;
+        FDHash.add memo_f f CSS.any;
         let res = f |> Ty.F.dnf |> CSS.map_conj norm_field_summand in
-        FDHash.remove memo_f fd ; res
+        FDHash.remove memo_f f ; res
     and norm_field_summand summand =
       match FToplevel.extract_smallest summand with
       | None ->
@@ -584,13 +572,12 @@ module Make(VS:VarSettings) = struct
       | Nil, Cons (constr, tl) ->
         let (f', _, f) = FC.destruct constr in
         let f = Ty.F.diff f' f in
-        let def = FDescr.of_field f in
-        if FDHash.mem memo_f def then
+        if FDHash.mem memo_f f then
           aux (prev, FCS.add constr prev') (cs,tl)
         else
-          let () = FDHash.add memo_f def () in
+          let () = FDHash.add memo_f f () in
           let res = norm_field f |> retry_with in
-          FDHash.remove memo_f def ; res
+          FDHash.remove memo_f f ; res
     in
     aux CS'.any cs
 


### PR DESCRIPTION
- in the tallying, use a more direct definitions of equal/hash without storing the node→vdescr mapping in a hash table
- simplify slightly `Polymorphic.Make` by requesting that the `Leaf` argument contains a reference to a `Node` module (it already requests a `node` type which will resolve to `Node.t`)