### PR TITLE
Simplify Ty.F and Ty.O operations

### DIFF
--- a/src/lib/sstt/core/components/fields.ml
+++ b/src/lib/sstt/core/components/fields.ml
@@ -65,6 +65,8 @@ module OTy(N:Node) = struct
   let cup = Bdd.cup
   let neg = Bdd.neg
   let diff = Bdd.diff
+  let conj = List.fold_left cap any
+  let disj = List.fold_left cup empty
 
   let get (ps,ns) =
     Atom.diff (Atom.conj ps) (Atom.disj ns)

--- a/src/lib/sstt/core/core.ml
+++ b/src/lib/sstt/core/core.ml
@@ -45,7 +45,7 @@ module Ty : Ty = struct
     let cap t1 t2 = F.cap t1 t2 |> simpl
     let cup t1 t2 = F.cup t1 t2 |> simpl
     let diff t1 t2 = F.diff t1 t2 |> simpl
-    let neg t = F.neg t |> simpl
+    let neg t = F.neg t (*|> simpl*) (* Negation preserves simplification *)
     let conj ts = F.conj ts |> simpl
     let disj ts = F.disj ts |> simpl
 
@@ -79,7 +79,7 @@ module Ty : Ty = struct
     let cap t1 t2 = O.cap t1 t2 |> simpl
     let cup t1 t2 = O.cup t1 t2 |> simpl
     let diff t1 t2 = O.diff t1 t2 |> simpl
-    let neg t = O.neg t |> simpl
+    let neg t = O.neg t (*|> simpl*) (* Negation preserves simplification *)
     let conj ts = O.conj ts |> simpl
     let disj ts = O.disj ts |> simpl
 

--- a/src/lib/sstt/core/core.ml
+++ b/src/lib/sstt/core/core.ml
@@ -33,8 +33,69 @@ module Ty : Ty = struct
   type subst = N.subst
 
   module VDescr = Node.VDescr
-  module F = VDescr.Descr.Records.FTy
-  module O = F.OTy
+  module F = struct
+    module F = VDescr.Descr.Records.FTy
+    type t = F.t
+
+    let simpl = F.simplify
+    let s f t = f t |> simpl
+    let s' f t = (*simpl*) t |> f
+
+    let any, empty = F.any |> simpl, F.empty |> simpl
+    let cap t1 t2 = F.cap t1 t2 |> simpl
+    let cup t1 t2 = F.cup t1 t2 |> simpl
+    let diff t1 t2 = F.diff t1 t2 |> simpl
+    let neg t = F.neg t |> simpl
+    let conj ts = F.conj ts |> simpl
+    let disj ts = F.disj ts |> simpl
+
+    let mk_var, mk_descr, get_descr = s F.mk_var, s F.mk_descr, s' F.get_descr
+    let get_vars = s' F.get_vars
+    let dnf, of_dnf = s' F.dnf, s F.of_dnf
+    let map f t = F.map f t |> simpl
+    let map_nodes f t = F.map_nodes f t |> simpl
+
+    let strengthen, weaken = F.strengthen, F.weaken
+
+    let is_empty t = F.is_empty t
+    let leq t1 t2 = F.equal t1 t2 || F.leq t1 t2
+    let equiv t1 t2 = F.equal t1 t2 || F.equiv t1 t2
+    let disjoint t1 t2 = F.disjoint t1 t2
+    let is_any t = F.is_any t
+
+    let compare, equal, hash = F.compare, F.equal, F.hash
+  end
+  module O = struct
+    module O = VDescr.Descr.Records.FTy.OTy
+    type t = O.t
+    module Atom = O.Atom
+
+    let simpl = O.simplify
+    let s f t = f t |> simpl
+    let s' f t = (*simpl*) t |> f
+
+    let any, empty, present, absent =
+      O.any |> simpl, O.empty |> simpl, O.present |> simpl, O.absent |> simpl
+    let cap t1 t2 = O.cap t1 t2 |> simpl
+    let cup t1 t2 = O.cup t1 t2 |> simpl
+    let diff t1 t2 = O.diff t1 t2 |> simpl
+    let neg t = O.neg t |> simpl
+    let conj ts = O.conj ts |> simpl
+    let disj ts = O.disj ts |> simpl
+
+    let mk, get, required, optional = s O.mk, s' O.get, s O.required, s O.optional
+    let dnf, of_dnf = s' O.dnf, s O.of_dnf
+    let map f t = O.map f t |> simpl
+    let map_nodes f t = O.map_nodes f t |> simpl
+
+    let is_empty t = O.is_empty t
+    let leq t1 t2 = O.equal t1 t2 || O.leq t1 t2
+    let equiv t1 t2 = O.equal t1 t2 || O.equiv t1 t2
+    let disjoint t1 t2 = O.disjoint t1 t2
+    let is_any t = O.is_any t
+
+    let compare, equal, hash = O.compare, O.equal, O.hash
+  end
   let simpl t = N.simplify t ; t
   let s f t = f t |> simpl
   let s' f t = simpl t |> f

--- a/src/lib/sstt/core/sigs.ml
+++ b/src/lib/sstt/core/sigs.ml
@@ -328,6 +328,8 @@ module type OTy = sig
                                 and type node := node
                                 and type atom := Atom.t
 
+    (** @inline *)
+    include SetTheoretic with type t := t
 
     val get : t -> Atom.t
 
@@ -345,7 +347,14 @@ module type OTy = sig
 
     (**@inline*)
     include SetTheoreticOps with type t := t
-  end
+end
+module type OTy' = sig
+
+  (**@inline*)
+  include OTy
+
+  val simplify : t -> t
+end
 
 (* Polymorphic layers *)
 
@@ -431,17 +440,26 @@ module type FTy = sig
 
   type node
   type t
-
-  module OTy : OTy with type node := node
+  type o
 
   (**@inline*)
   include Polymorphic with type t := t and type node := node
-    and type leaf := OTy.t and type var := RowVar.t
+    and type leaf := o and type var := RowVar.t
     and module VarSet := RowVarSet
     and module VarMap := RowVarMap
 
   (**@inline*)
   include SetTheoreticOps with type t := t
+end
+module type FTy' = sig
+  type node
+
+  module OTy : OTy' with type node := node
+
+  (**@inline*)
+  include FTy with type o := OTy.t and type node := node
+  
+  val simplify : t -> t
 end
 
 (* Enums *)
@@ -700,8 +718,7 @@ module type Records = sig
 
   type node
 
-  (** @canonical Sstt.Ty.F *)
-  module FTy : FTy with type node := node
+  module FTy : FTy' with type node := node
 
   (** @inline*)
   include ComponentBase with type t := t
@@ -1256,6 +1273,9 @@ module type Ty = sig
 
   (** {1 Field types and optional types }*)
 
-  module F = VDescr.Descr.Records.FTy
-  module O = F.OTy
+  module O : OTy with type node := t
+                  and type t = VDescr.Descr.Records.FTy.OTy.t
+  module F : FTy with type node := t
+                  and type t = VDescr.Descr.Records.FTy.t
+                  and type o := O.t
 end


### PR DESCRIPTION
`Ty.O` and `Ty.F` functions now maintain a simplified version.
Only the "top-level" bindings `Ty.O` and `Ty.F` do perform simplifications, accessing those functions through `Records.FTy` and `Records,FTy.OTy` will not triggering simplification (as for types: only top-level functions `Ty.*` maintain simplified types, not the `VDescr` operations etc).

Slight overhead (~1%) on MLsem tests, but avoid combinatorial explosion on more complex examples.