### PR TITLE
Improve cache invalidation

### DIFF
--- a/src/lib/sstt/core/components/arrows.ml
+++ b/src/lib/sstt/core/components/arrows.ml
@@ -30,12 +30,25 @@ module Make(N:Node) = struct
   let cup = Bdd.cup
   let neg = Bdd.neg
   let diff = Bdd.diff
+
+  (* The general case splits into the two branches [psi (t1\s1) t2 ps] and
+     [psi t1 (t2&s2) ps]. When [t1] and [s1] are disjoint, [t1\s1] is
+     equivalent to [t1], so the first branch implies the second one (as [psi]
+     can only become true when [t1] or [t2] gets smaller) and is thus the only
+     one to consider;
+     symmetrically, when [t2] is a subtype of [s2], [t2&s2] is equivalent to
+     [t2] and the second branch implies the first one.
+     Note that in each of these two cases we must keep the branch as it is in
+     the general case (with [N.diff t1 s1], resp. [N.cap t2 s2]) rather than
+     use the equivalent [t1] (resp. [t2]): this keeps [psi] monotonic w.r.t.
+     the emptiness assumptions of the cache. *)
   let rec psi t1 t2 ps =
     N.is_empty t1 || N.is_empty t2 ||
     match ps with
     | [] -> false
     | (s1,s2)::ps ->
-      if N.disjoint t1 s1 || N.leq t2 s2 then psi t1 t2 ps
+      if N.disjoint t1 s1 then psi (N.diff t1 s1) t2 ps
+      else if N.leq t2 s2 then psi t1 (N.cap t2 s2) ps
       else psi (N.diff t1 s1) t2 ps && psi t1 (N.cap t2 s2) ps
 
   let is_clause_empty' ps (t1,t2) =

--- a/src/lib/sstt/core/components/records.ml
+++ b/src/lib/sstt/core/components/records.ml
@@ -176,13 +176,29 @@ module Make(N:Node) = struct
     let tests = ns |> List.map (fun r -> r.Atom.tail, Atom.to_tuple dom r) in
     (tl, p), tests
 
+  (* If a component of [ss] is disjoint from the corresponding component of
+     [tt], then the line of the general case associated to this component
+     implies all the other ones, so that it is the only one to consider.
+     Note that we must return this line ([FTy.diff s t] at this position) rather
+     than [ss] itself, even though both are semantically equal: this keeps
+     [psi] monotonic w.r.t. the emptiness assumptions of the cache. *)
+  let rec disjoint_line ss tt =
+    match ss, tt with
+    | [], [] -> None
+    | s::ss, t::tt ->
+      if FTy.disjoint s t then Some ((FTy.diff s t)::ss)
+      else disjoint_line ss tt |> Option.map (fun ss -> s::ss)
+    | _, _ -> assert false
+
   let rec psi acc ss ts =
     List.exists FTy.is_empty ss ||
     match ts with
     | [] -> false
     | tt::ts ->
-      if List.exists2 FTy.disjoint ss tt then psi acc ss ts
-      else fold_distribute_comb (fun acc ss -> acc && psi acc ss ts) FTy.diff acc ss tt
+      match disjoint_line ss tt with
+      | Some ss -> psi acc ss ts
+      | None ->
+        fold_distribute_comb (fun acc ss -> acc && psi acc ss ts) FTy.diff acc ss tt
   let is_clause_empty (ps,ns,b) =
     if b then
       let (tl,p), ns = dnf_line_to_types (ps, ns) in

--- a/src/lib/sstt/core/components/tuples.ml
+++ b/src/lib/sstt/core/components/tuples.ml
@@ -50,13 +50,29 @@ module MakeC(N:Node) = struct
     let init = fun () -> List.init n (fun _ -> N.empty) in
     mapn init N.disj ps
 
+  (* If a component of [ss] is disjoint from the corresponding component of
+     [tt], then the line of the general case associated to this component
+     implies all the other ones, so that it is the only one to consider.
+     Note that we must return this line ([N.diff s t] at this position) rather
+     than [ss] itself, even though both are semantically equal: this keeps
+     [psi] monotonic w.r.t. the emptiness assumptions of the cache. *)
+  let rec disjoint_line ss tt =
+    match ss, tt with
+    | [], [] -> None
+    | s::ss, t::tt ->
+      if N.disjoint s t then Some ((N.diff s t)::ss)
+      else disjoint_line ss tt |> Option.map (fun ss -> s::ss)
+    | _, _ -> assert false
+
   let rec psi acc ss ts =
     List.exists N.is_empty ss ||
     match ts with
     | [] -> false
     | tt::ts ->
-      if List.exists2 N.disjoint ss tt then psi acc ss ts
-      else fold_distribute_comb (fun acc ss -> acc && psi acc ss ts) N.diff acc ss tt
+      match disjoint_line ss tt with
+      | Some ss -> psi acc ss ts
+      | None ->
+        fold_distribute_comb (fun acc ss -> acc && psi acc ss ts) N.diff acc ss tt
   let is_clause_empty n (ps,ns,b) =
     not b || psi true (conj n ps) ns
   let is_empty (n,t) = Bdd.for_all_lines (is_clause_empty n) t

--- a/src/lib/sstt/core/node.ml
+++ b/src/lib/sstt/core/node.ml
@@ -123,7 +123,7 @@ include (struct
     (* The PreNode module that contain the entry points of all functions on types. *)
 
     (* Subtyping cache *)
-    module Table = Bttable.MakeOpt(PreNode)(Bool)
+    module Table = Bttable.MakeOpt(PreNode)
 
 
     (** The memoization cache. Two caches are kept, one for simplified the other
@@ -299,7 +299,7 @@ include (struct
 
     let is_empty_rec t =
       let cache = get_is_empty_cache () in
-      begin match Table.find ~default:true cache t with
+      begin match Table.find cache t with
         | Some b -> b
         | None ->
           let b = VDescr.is_empty (def t) in

--- a/src/lib/sstt/core/utils/bttable.ml
+++ b/src/lib/sstt/core/utils/bttable.ml
@@ -1,21 +1,22 @@
 exception InvalidAccess
 (** Raised if a entry is used more than once. *)
 
-module MakeOpt(V : Hashtbl.HashedType)(R : sig type t val equal : t -> t-> bool end): sig
+module MakeOpt(V : Hashtbl.HashedType): sig
   (**
      Hash table specialized for computations over co-inductive structures.
 
-      This table can be used for computations over co-inductive structures whose
-      results depend on an initial guess. When exploring a co-inductive value
-      [v : V.t], we first fix its result to an initial guess before exploring it.
-      If we find it again, return the initial guess. When coming back after exploration,
-      if the result is consistent with the initial guess we can simply return it.
-      If not, we need to invalidate all results stored in the table that depended
-      (directly or indirectly) on the initial guess.
+      This table can be used for boolean computations over co-inductive
+      structures whose results depend on an initial guess, the initial guess
+      being [true]. When exploring a co-inductive value [v : V.t], we first fix
+      its result to [true] before exploring it. If we find it again, return
+      [true]. When coming back after exploration, if the result is [true] the
+      guess was correct and we can simply return it. If it is [false], we need
+      to invalidate the results stored in the table that depended (directly or
+      indirectly) on the initial guess.
       This fits nicely with a look-up table pattern :
 
-     - first, one looks for [v] in the table, using [find ~default:r table v]
-     - if [v] is not in the table, it associates an initial result [r : R.t],
+     - first, one looks for [v] in the table, using [find table v]
+     - if [v] is not in the table, it associates the result [true] to it,
           The exploration of [v] can continue.
      - if [v] is in the table, it means it is encountered again. The
           value stored is returned as [Some r] and all values that are curently being
@@ -23,24 +24,34 @@ module MakeOpt(V : Hashtbl.HashedType)(R : sig type t val equal : t -> t-> bool 
 
      - when returning from the initial exploration of [v] with a computed
        result [r'], one needs to update the result [update table v r']:
-     - if [R.equal r r'] then the initial guess was correct the table is in a consistent state.
+     - if [r'] is [true] then the initial guess was correct the table is in a consistent state.
      - otherwise the transitive dependencies of [v] are removed from the table: they
           were computed while making the (wrong) hypothesis that the result for
-          [v] was [r], while it is [r']. Later calls to [find ~default:r table v]
-       will return [r'] unless it is itself invalidated.
+          [v] was [true], while it is [false]. Later calls to [find table v]
+       will return [false].
 
       {@ocaml[ let rec explore table v =
 
-        match find ~default:r table v with (* if [v] is not [Active] yet it
-        binds it to [d] in the table *)
+        match find table v with (* if [v] is not [Active] yet it
+        binds it to [true] in the table *)
         | Some r -> r                     (* [v] was bound to some value *)
         | None ->
           let r' = (* COMPUTATION, may call explore recursively *) in
 
-          (* this will invalidate the dependencies if [not (R.equal r r')] *)
+          (* this will invalidate the dependencies if [r'] is [false] *)
           update table v r'
 
       ]}
+
+      {2 Monotonicity}
+
+      The computation is assumed to be {e monotonic} w.r.t. the guesses stored
+      in the table: adding the hypothesis that the result for some value is
+      [true] can only make more results [true]. Consequently, a computed
+      [false] does not rely on any hypothesis (it would still be [false] with
+      fewer hypotheses), and thus never has to be invalidated: results equal to
+      [false] are definitive. Only results equal to [true] (be they guesses of
+      ongoing explorations or computed results) may be invalidated.
   *)
 
   type t
@@ -52,16 +63,16 @@ module MakeOpt(V : Hashtbl.HashedType)(R : sig type t val equal : t -> t-> bool 
   val clear : t -> unit
   (** Clears the table. *)
 
-  val find : default:R.t -> t -> V.t -> R.t option
+  val find : t -> V.t -> bool option
   (** Retrieves the result associated with a value.
-      If the value is not in the table, the supplied [default] result
+      If the value is not in the table, the initial guess [true]
       is added and a entry is returned.
   *)
 
-  val update : ?naive:bool -> t -> V.t -> R.t -> unit
+  val update : t -> V.t -> bool -> unit
   (** Updates the value associated with the value that created the entry.
-        If the supplied value is not equal to the original one, all values in
-        the table whose result dependend on the original result are removed from
+        If the supplied value is [false], all values in
+        the table whose result dependend on the initial guess are removed from
         the table.
 
       @raise InvalidAccess if the value is not already in the table.
@@ -72,12 +83,21 @@ end = struct
 
   type stack = entry list
   and entry = {
-    mutable dependencies : stack list;  (* the top of the stack at the time the entry was accessed *)
-    mutable result : R.t option;        (* the result stored in this entry. None indicates that
-                                           this entry is stale. We do not remove entries but but
-                                           just overwrite stale entries when they are added again.
-                                        *)
+    mutable dependencies : stack list;  (* the top of the stack at the time the entry was accessed.
+                                           Only recorded for provisional entries, as definitive
+                                           ones are never invalidated. *)
+    mutable status : status;            (* the result stored in this entry. *)
   }
+  and status =
+    | Stale                             (* This entry has been invalidated. We do not remove
+                                           entries but just overwrite stale entries when they
+                                           are added again. *)
+    | Provisional                       (* Result [true]: either the guess of an entry currently
+                                           being explored, or a result that may depend on such a
+                                           guess. It may thus be invalidated. *)
+    | Definitive                        (* Result [false]: by monotonicity of the computation,
+                                           it does not depend on any guess and is never
+                                           invalidated. *)
   and t = {
     table :  entry H.t;                 (* The table of all entries *)
     mutable stack : stack;              (* The stack of entries. *)
@@ -85,74 +105,86 @@ end = struct
   let create () = { table = H.create 0; stack = []}
   let clear t = H.clear t.table; t.stack <- []
 
-  let find ~default t key =
+  let find t key =
     match H.find_opt t.table key with
-    | None | Some { result = None; _ } ->
+    | None | Some { status = Stale; _ } ->
       (* The key is not in the table or has a stale entry, overwrite it *)
-      let entry = { dependencies = []; result = Some default } in
+      let entry = { dependencies = []; status = Provisional } in
       t.stack <- entry :: t.stack;
       H.replace t.table key entry;
       None
+    | Some { status = Definitive; _ } ->
+      (* No dependency to record: this result will never be invalidated *)
+      Some false
     | Some entry ->
       entry.dependencies <- t.stack::entry.dependencies;
-      entry.result
+      Some true
 
   (* Invalidate the stack until we reach the stop level. We recursively
-     invalidate the dependencies of each entry. We set the result of an
-     entry to None, to mark it as stale. This allows us to not remove
+     invalidate the dependencies of each entry. We set the status of an
+     entry to Stale. This allows us to not remove
      the entry from the table (avoid a table look-up using the key).
      This also ensures that an entry is not invalidated more than once.
+
+     When we reach a definitive entry, we can stop walking this stack: the
+     entries below it only depend on the invalidated result through it, and
+     its own result will not change.
   *)
   let rec invalidate_stack stop stack todo =
     if stack == stop then invalidate stop todo
     else
       match stack with
       |  entry :: next ->
-        if entry.result <> None then begin
-          entry.result <- None;
-          invalidate stop entry.dependencies
-        end;
-        invalidate_stack stop next todo
+        begin match entry.status with
+          | Definitive -> invalidate stop todo
+          | Stale -> invalidate_stack stop next todo
+          | Provisional ->
+            entry.status <- Stale;
+            invalidate stop entry.dependencies;
+            invalidate_stack stop next todo
+        end
       | [] -> invalidate stop todo
   and[@inline always] invalidate stop = function
       [] -> ()
     | dep :: todo -> invalidate_stack stop dep todo
 
-  let[@warning "-27"] update ?(naive=false) t _key r =
-    match t.stack  with
-    | {result = Some old_r; _ } as entry ::next ->
-      if not (R.equal r old_r) then begin
-        entry.result <- Some r;
+  let update t _key r =
+    match t.stack with
+    | ({status = Provisional; _ } as entry) ::next ->
+      if not r then begin
+        entry.status <- Definitive;
         invalidate t.stack entry.dependencies;
+        entry.dependencies <- [] (* This entry will never be invalidated *)
       end;
       t.stack <- next
     | _ -> raise InvalidAccess
 end
-module MakeSimple(V : Set.OrderedType)(R : sig type t val equal : t -> t-> bool end): sig
+
+module MakeSimple(V : Set.OrderedType): sig
   type t
   val create : unit -> t
   val clear : t -> unit
-  val find : default:R.t -> t -> V.t -> R.t option
-  val update : ?naive:bool -> t -> V.t -> R.t -> unit
+  val find : t -> V.t -> bool option
+  val update : t -> V.t -> bool -> unit
 
 end = struct
 
   module M = Map.Make(V)
 
-  type t = (R.t M.t list) ref
+  type t = (bool M.t list) ref
 
   let create () = ref ([M.empty])
   let clear r = r := [ M.empty ]
-  let find ~default t key =
+  let find t key =
     let cache = match !t with [] -> assert false | c :: _ -> c in
     match M.find_opt key cache with
       Some _ as v -> v
     | None ->
-      let new_cache = M.add key default cache in
+      let new_cache = M.add key true cache in
       t := new_cache :: !t;
       None
 
-  let update ?(naive=false) t key r =
+  let update t key r =
     match !t with
     | [] | [ _ ] -> raise InvalidAccess
     | cache :: old_cache :: prev_stack ->
@@ -160,7 +192,14 @@ end = struct
       | None -> raise InvalidAccess
       | Some old_r ->
         let new_cache =
-          if R.equal r old_r && not naive then cache else M.add key r old_cache
+          if r = old_r then cache
+          else
+            (* The guess [true] was wrong: restore the previous cache, but keep
+               the results equal to [false] computed in the meantime, as they
+               cannot depend on the wrong guess (see MakeOpt). *)
+            old_cache
+            |> M.fold (fun k b acc -> if b then acc else M.add k b acc) cache
+            |> M.add key r
         in
         t := (new_cache :: prev_stack)
 end

--- a/src/lib/sstt/core/utils/bttable.ml
+++ b/src/lib/sstt/core/utils/bttable.ml
@@ -169,37 +169,36 @@ module MakeSimple(V : Set.OrderedType): sig
 
 end = struct
 
-  module M = Map.Make(V)
+  module S = Set.Make(V)
 
-  type t = (bool M.t list) ref
+  (* [t] contains the keys whose result is [true] (a guess, that may be
+     invalidated), [f] those whose result is [false] (definitive). *)
+  type cache = { t : S.t ; f : S.t }
 
-  let create () = ref ([M.empty])
-  let clear r = r := [ M.empty ]
+  type t = (cache list) ref
+
+  let empty_cache = { t = S.empty ; f = S.empty }
+
+  let create () = ref ([empty_cache])
+  let clear r = r := [ empty_cache ]
   let find t key =
     let cache = match !t with [] -> assert false | c :: _ -> c in
-    match M.find_opt key cache with
-      Some _ as v -> v
-    | None ->
-      let new_cache = M.add key true cache in
+    if S.mem key cache.t then Some true
+    else if S.mem key cache.f then Some false
+    else begin
+      let new_cache = { cache with t = S.add key cache.t } in
       t := new_cache :: !t;
       None
+    end
 
   let update t key r =
     match !t with
     | [] | [ _ ] -> raise InvalidAccess
     | cache :: old_cache :: prev_stack ->
-      match M.find_opt key cache with
-      | None -> raise InvalidAccess
-      | Some old_r ->
-        let new_cache =
-          if r = old_r then cache
-          else
-            (* The guess [true] was wrong: restore the previous cache, but keep
-               the results equal to [false] computed in the meantime, as they
-               cannot depend on the wrong guess (see MakeOpt). *)
-            old_cache
-            |> M.fold (fun k b acc -> if b then acc else M.add k b acc) cache
-            |> M.add key r
-        in
-        t := (new_cache :: prev_stack)
+      if S.mem key cache.t |> not then raise InvalidAccess ;
+      let new_cache =
+        if r then cache
+        else { old_cache with f = S.add key cache.f }
+      in
+      t := (new_cache :: prev_stack)
 end

--- a/src/lib/sstt/core/utils/bttable.ml
+++ b/src/lib/sstt/core/utils/bttable.ml
@@ -1,34 +1,33 @@
 exception InvalidAccess
 (** Raised if a entry is used more than once. *)
 
-module MakeOpt(V : Hashtbl.HashedType): sig
+module type S = sig
   (**
-     Hash table specialized for computations over co-inductive structures.
+     Table specialized for computations over co-inductive structures.
 
       This table can be used for boolean computations over co-inductive
       structures whose results depend on an initial guess, the initial guess
-      being [true]. When exploring a co-inductive value [v : V.t], we first fix
+      being [true]. When exploring a co-inductive value [v : key], we first fix
       its result to [true] before exploring it. If we find it again, return
       [true]. When coming back after exploration, if the result is [true] the
-      guess was correct and we can simply return it. If it is [false], we need
-      to invalidate the results stored in the table that depended (directly or
-      indirectly) on the initial guess.
+      guess was correct and we can simply return it. If it is [false], the
+      results that depended (directly or indirectly) on the initial guess
+      cannot be trusted anymore.
       This fits nicely with a look-up table pattern :
 
      - first, one looks for [v] in the table, using [find table v]
      - if [v] is not in the table, it associates the result [true] to it,
           The exploration of [v] can continue.
      - if [v] is in the table, it means it is encountered again. The
-          value stored is returned as [Some r] and all values that are curently being
-          explored become [v]'s direct dependencies, which we record.
+          value stored is returned as [Some r].
 
      - when returning from the initial exploration of [v] with a computed
        result [r'], one needs to update the result [update table v r']:
      - if [r'] is [true] then the initial guess was correct the table is in a consistent state.
-     - otherwise the transitive dependencies of [v] are removed from the table: they
-          were computed while making the (wrong) hypothesis that the result for
-          [v] was [true], while it is [false]. Later calls to [find table v]
-       will return [false].
+     - otherwise the results that depended on the initial guess are removed from
+          the table: they were computed while making the (wrong) hypothesis
+          that the result for [v] was [true], while it is [false]. Later calls
+          to [find table v] will return [false].
 
       {@ocaml[ let rec explore table v =
 
@@ -38,7 +37,7 @@ module MakeOpt(V : Hashtbl.HashedType): sig
         | None ->
           let r' = (* COMPUTATION, may call explore recursively *) in
 
-          (* this will invalidate the dependencies if [r'] is [false] *)
+          (* this will discard the results depending on the guess if [r'] is [false] *)
           update table v r'
 
       ]}
@@ -49,10 +48,13 @@ module MakeOpt(V : Hashtbl.HashedType): sig
       in the table: adding the hypothesis that the result for some value is
       [true] can only make more results [true]. Consequently, a computed
       [false] does not rely on any hypothesis (it would still be [false] with
-      fewer hypotheses), and thus never has to be invalidated: results equal to
+      fewer hypotheses), and thus never has to be discarded: results equal to
       [false] are definitive. Only results equal to [true] (be they guesses of
-      ongoing explorations or computed results) may be invalidated.
+      ongoing explorations or computed results) may be discarded.
   *)
+
+  type key
+  (** The type of the values explored. *)
 
   type t
   (** The type of the table.*)
@@ -63,13 +65,13 @@ module MakeOpt(V : Hashtbl.HashedType): sig
   val clear : t -> unit
   (** Clears the table. *)
 
-  val find : t -> V.t -> bool option
+  val find : t -> key -> bool option
   (** Retrieves the result associated with a value.
       If the value is not in the table, the initial guess [true]
       is added and a entry is returned.
   *)
 
-  val update : t -> V.t -> bool -> unit
+  val update : t -> key -> bool -> unit
   (** Updates the value associated with the value that created the entry.
         If the supplied value is [false], all values in
         the table whose result dependend on the initial guess are removed from
@@ -77,9 +79,15 @@ module MakeOpt(V : Hashtbl.HashedType): sig
 
       @raise InvalidAccess if the value is not already in the table.
   *)
+end
 
-end = struct
+(** Hash table implementation of {!S}. The results that depend on a guess are
+    tracked precisely, so that only them are discarded when the guess turns out
+    to be wrong. *)
+module MakeOpt(V : Hashtbl.HashedType): S with type key = V.t = struct
   module H = Hashtbl.Make(V)
+
+  type key = V.t
 
   type stack = entry list
   and entry = {
@@ -160,16 +168,14 @@ end = struct
     | _ -> raise InvalidAccess
 end
 
-module MakeSimple(V : Set.OrderedType): sig
-  type t
-  val create : unit -> t
-  val clear : t -> unit
-  val find : t -> V.t -> bool option
-  val update : t -> V.t -> bool -> unit
-
-end = struct
+(** Straightforward implementation of {!S}, using persistent sets: when a guess
+    turns out to be wrong, all the results equal to [true] that were computed
+    in the meantime are discarded, even those that did not depend on it. *)
+module MakeSimple(V : Set.OrderedType): S with type key = V.t = struct
 
   module S = Set.Make(V)
+
+  type key = V.t
 
   (* [t] contains the keys whose result is [true] (a guess, that may be
      invalidated), [f] those whose result is [false] (definitive). *)
@@ -201,4 +207,30 @@ end = struct
         else { old_cache with f = S.add key cache.f }
       in
       t := (new_cache :: prev_stack)
+end
+
+(** Implementation of {!S} without any caching: only the keys currently being
+    explored are remembered, so that a key is never explored twice in the same
+    call stack (which is enough to guarantee termination in theory).
+    Every other result is recomputed from scratch. Useful to
+    measure what the caching strategies of {!MakeOpt} and {!MakeSimple} actually buy. *)
+module MakeNaive(V : Set.OrderedType): S with type key = V.t = struct
+
+  module S = Set.Make(V)
+
+  type key = V.t
+
+  (* The keys currently being explored, all of them guessed to be [true]. *)
+  type t = S.t ref
+
+  let create () = ref S.empty
+  let clear t = t := S.empty
+
+  let find t key =
+    if S.mem key !t then Some true
+    else begin t := S.add key !t ; None end
+
+  let update t key _r =
+    if S.mem key !t |> not then raise InvalidAccess ;
+    t := S.remove key !t
 end


### PR DESCRIPTION
- First commit makes `is_empty` truly monotonic (an additional "is empty" hypothesis can only make more types empty)
- Second commit updates Bttable so that it uses this monotonicity: `false` (i.e. non-empty) results are never invalidated.